### PR TITLE
speeding up algorithm slightly

### DIFF
--- a/anagrammer/anagrammer.go
+++ b/anagrammer/anagrammer.go
@@ -30,7 +30,7 @@ func LoadDawgs(dawgPath string) {
 	}
 }
 
-const BlankPos = 31
+const BlankPos = gaddag.MaxAlphabetSize
 
 type AnagramMode int
 
@@ -56,7 +56,7 @@ func Anagram(letters string, dawg gaddag.SimpleDawg, mode AnagramMode) []string 
 	gd := gaddag.SimpleGaddag(dawg)
 	alphabet := gd.GetAlphabet()
 	// 31 maximum letters allowed. rack[31] will be the blank.
-	rack := make([]uint8, 32)
+	rack := make([]uint8, gaddag.MaxAlphabetSize+1)
 	for _, r := range runes {
 		if r != '?' {
 			idx, err := alphabet.Val(r)

--- a/anagrammer/rpc_api.go
+++ b/anagrammer/rpc_api.go
@@ -49,7 +49,7 @@ func (a *AnagramService) Anagram(r *http.Request, args *AnagramServiceArgs,
 		mode = ModeExact
 	}
 
-	if strings.Count(args.Letters, "?") > 2 {
+	if strings.Count(args.Letters, "?") > 4 {
 		if subtle.ConstantTimeCompare([]byte(args.AuthToken), []byte(AuthorizationKey)) != 1 {
 			return errors.New("query too complex")
 		}

--- a/anagrammer/rpc_api.go
+++ b/anagrammer/rpc_api.go
@@ -49,7 +49,7 @@ func (a *AnagramService) Anagram(r *http.Request, args *AnagramServiceArgs,
 		mode = ModeExact
 	}
 
-	if strings.Count(args.Letters, "?") > 4 {
+	if strings.Count(args.Letters, "?") > 8 {
 		if subtle.ConstantTimeCompare([]byte(args.AuthToken), []byte(AuthorizationKey)) != 1 {
 			return errors.New("query too complex")
 		}

--- a/gaddag/alphabet.go
+++ b/gaddag/alphabet.go
@@ -55,6 +55,9 @@ func (a *Alphabet) Init() {
 // Return the 'value' of this rune in the alphabet; i.e. a number from
 // 0 to 31
 func (a Alphabet) Val(r rune) (uint32, error) {
+	if a.athruz {
+		return uint32(r - 'A'), nil
+	}
 	val, ok := a.vals[r]
 	if ok {
 		return val, nil
@@ -64,6 +67,9 @@ func (a Alphabet) Val(r rune) (uint32, error) {
 
 // Return the letter that this position in the alphabet corresponds to.
 func (a Alphabet) Letter(b byte) rune {
+	if a.athruz {
+		return rune(b) + 'A'
+	}
 	return a.letters[b]
 }
 

--- a/gaddag/alphabet.go
+++ b/gaddag/alphabet.go
@@ -14,16 +14,22 @@ const (
 
 type LetterSlice []rune
 
-// This file defines an alphabet.
+// Alphabet defines an alphabet.
 // For now, don't create gaddags for alphabets with more than 31 unique
 // runes. Our file format will not yet support it.
-// The vals map has uint32 values for simplicity in serialization. It's ok
-// to waste a few bytes here and there...
 type Alphabet struct {
-	vals        map[rune]uint32
-	letters     map[byte]rune
+	// vals is a map of the actual physical letter rune (like 'A') to a
+	// number representing it, from 0 to MaxAlphabetSize.
+	// The vals map has uint32 values for simplicity in serialization. It's ok
+	// to waste a few bytes here and there...
+	vals map[rune]uint32
+	// letters is a map of the 0 to MaxAlphabetSize value back to a letter.
+	letters map[byte]rune
+
 	letterSlice LetterSlice
 	curIdx      uint32
+	// true if alphabet contains just A through Z with no gaps in between.
+	athruz bool
 }
 
 // update the alphabet map.
@@ -31,12 +37,12 @@ func (a *Alphabet) update(word string) error {
 	for _, char := range word {
 		if _, ok := a.vals[char]; !ok {
 			a.vals[char] = a.curIdx
-			a.curIdx += 1
+			a.curIdx++
 		}
 	}
 
 	if a.curIdx == MaxAlphabetSize {
-		return fmt.Errorf("Exceeded max alphabet size.")
+		return fmt.Errorf("exceeded max alphabet size")
 	}
 	return nil
 }
@@ -68,7 +74,7 @@ func (a Alphabet) NumLetters() uint8 {
 
 func (a *Alphabet) genLetterSlice() {
 	a.letterSlice = []rune{}
-	for rn, _ := range a.vals {
+	for rn := range a.vals {
 		a.letterSlice = append(a.letterSlice, rn)
 	}
 	sort.Sort(a.letterSlice)

--- a/gaddag/gaddag.go
+++ b/gaddag/gaddag.go
@@ -25,8 +25,9 @@ import (
 // If the node has no arcs, the arc array is empty.
 
 type SimpleGaddag struct {
-	arr      []uint32
-	alphabet *Alphabet
+	arr        []uint32
+	alphabet   *Alphabet
+	numLetters uint32
 }
 
 type SimpleDawg SimpleGaddag
@@ -76,6 +77,8 @@ func (g SimpleGaddag) GetLetterSet(nodeIdx uint32) uint32 {
 	// Look in the letter set list for this code. We use g[0] because
 	// that contains the offset in `g` where the letter sets begin.
 	// (See serialization code).
+	// Note: for some reason g.numLetters seems to be a little slower
+	// than g.arr[0].
 	return g.arr[letterSetCode+2+g.arr[0]]
 }
 
@@ -118,7 +121,7 @@ func (g SimpleGaddag) NumArcs(nodeIdx uint32) byte {
 
 // GetRootNodeIndex gets the index of the root node.
 func (g SimpleGaddag) GetRootNodeIndex() uint32 {
-	alphabetLength := g.arr[0]
+	alphabetLength := g.numLetters
 	letterSets := g.arr[alphabetLength+1]
 	return letterSets + alphabetLength + 2
 }
@@ -144,6 +147,7 @@ func (g *SimpleGaddag) SetAlphabet() {
 	}
 	alphabet.athruz = athruz
 	g.alphabet = &alphabet
+	g.numLetters = numRunes
 	log.Printf("Alphabet athruz is %v", alphabet.athruz)
 }
 

--- a/gaddag/gaddag.go
+++ b/gaddag/gaddag.go
@@ -82,10 +82,19 @@ func (g SimpleGaddag) GetLetterSet(nodeIdx uint32) uint32 {
 // InLetterSet returns whether the `letter` is in the node at `nodeIdx`'s
 // letter set.
 func (g SimpleGaddag) InLetterSet(letter rune, nodeIdx uint32) bool {
-	letterSet := g.GetLetterSet(nodeIdx)
-	idx, ok := g.alphabet.vals[letter]
-	if !ok { // The ^ character, likely, when looking up single-letter words.
+	if letter == SeparationToken {
 		return false
+	}
+	var idx uint32
+	letterSet := g.GetLetterSet(nodeIdx)
+	if g.alphabet.athruz {
+		idx = uint32(letter) - uint32('A')
+	} else {
+		var ok bool
+		idx, ok = g.alphabet.vals[letter]
+		if !ok { // The ^ character, likely, when looking up single-letter words.
+			return false
+		}
 	}
 	return letterSet&(1<<idx) != 0
 }
@@ -121,11 +130,21 @@ func (g *SimpleGaddag) SetAlphabet() {
 	alphabet.Init()
 	// The very first element of the array is the alphabet size.
 	numRunes := g.arr[0]
+	athruz := false
+	runeCt := uint32(65)
 	for i := uint32(0); i < numRunes; i++ {
 		alphabet.vals[rune(g.arr[i+1])] = i
 		alphabet.letters[byte(i)] = rune(g.arr[i+1])
+		if runeCt == g.arr[i+1] {
+			runeCt++
+		}
 	}
+	if runeCt == uint32(91) {
+		athruz = true
+	}
+	alphabet.athruz = athruz
 	g.alphabet = &alphabet
+	log.Printf("Alphabet athruz is %v", alphabet.athruz)
 }
 
 func (g SimpleGaddag) GetAlphabet() *Alphabet {

--- a/gaddag/gaddag.go
+++ b/gaddag/gaddag.go
@@ -90,8 +90,9 @@ func (g SimpleGaddag) InLetterSet(letter rune, nodeIdx uint32) bool {
 	}
 	var idx uint32
 	letterSet := g.GetLetterSet(nodeIdx)
+
 	if g.alphabet.athruz {
-		idx = uint32(letter) - uint32('A')
+		idx = uint32(letter - 'A')
 	} else {
 		var ok bool
 		idx, ok = g.alphabet.vals[letter]

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 var dawgPath = flag.String("dawgpath", "", "path for dawgs")
+var profilePath = flag.String("profilepath", "", "path for profile")
 
 func addTimeout(i *rpc.RequestInfo) *http.Request {
 	var timeout time.Duration
@@ -68,12 +69,14 @@ func main() {
 	flag.Parse()
 	anagrammer.LoadDawgs(*dawgPath)
 
-	f, err := os.Create("profile.ppf")
-	if err != nil {
-		log.Fatal(err)
+	if *profilePath != "" {
+		f, err := os.Create(*profilePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
 	}
-	pprof.StartCPUProfile(f)
-	defer pprof.StopCPUProfile()
 
 	http.HandleFunc("/", mainHandler)
 	http.HandleFunc("/static/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- after e8a88a6, exact mode for `AEINST????` goes from ~1.102 seconds to ~0.9714 seconds (avg of 10 runs, on my 2013 macbook pro)
- after bc1ca0c, goes down to 0.9025 ms
- after fcf15f1, goes down to 0.4536 ms!!