### PR TITLE
allow precaching

### DIFF
--- a/alphabet/letter_distribution.go
+++ b/alphabet/letter_distribution.go
@@ -4,11 +4,11 @@ import (
 	"encoding/csv"
 	"io"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/config"
 )
 
@@ -42,7 +42,7 @@ func NamedLetterDistribution(cfg *config.Config, name string) (*LetterDistributi
 	name = strings.ToLower(name)
 	filename := filepath.Join(cfg.LetterDistributionPath, name+".csv")
 
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/automatic/logfile_analysis.go
+++ b/automatic/logfile_analysis.go
@@ -4,17 +4,17 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/montecarlo"
 )
 
 // AnalyzeLogFile analyzes the given game CSV file and spits out a bunch of
 // statistics.
 func AnalyzeLogFile(filepath string) (string, error) {
-	file, err := os.Open(filepath)
+	file, err := cache.Open(filepath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/make_leaves_structure/main.go
+++ b/cmd/make_leaves_structure/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alecthomas/mph"
 	"github.com/domino14/macondo/alphabet"
+	"github.com/domino14/macondo/cache"
 	"github.com/rs/zerolog/log"
 )
 
@@ -44,7 +45,7 @@ func parseIntoMPH(filename string, alphabetName string) {
 
 	hb := mph.Builder()
 	fmt.Println(filename)
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}

--- a/gaddag/dawg.go
+++ b/gaddag/dawg.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"io"
 
-	"os"
-
 	"github.com/domino14/macondo/alphabet"
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/gaddagmaker"
 	"github.com/rs/zerolog/log"
 )
@@ -66,7 +65,7 @@ func loadCommonDagStructure(stream io.Reader) ([]uint32, []alphabet.LetterSet,
 // LoadDawg loads a dawg from a file and returns a *SimpleDawg
 func LoadDawg(filename string) (*SimpleDawg, error) {
 	log.Debug().Msgf("Loading %v ...", filename)
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		log.Debug().Msgf("Could not load %v", filename)
 		return nil, err

--- a/gaddag/gaddag.go
+++ b/gaddag/gaddag.go
@@ -6,11 +6,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"os"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/domino14/macondo/alphabet"
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/gaddagmaker"
 )
 
@@ -66,7 +66,7 @@ func GaddagToSimpleGaddag(g *gaddagmaker.Gaddag) *SimpleGaddag {
 // LoadGaddag loads a gaddag from a file and returns a *SimpleGaddag structure.
 func LoadGaddag(filename string) (*SimpleGaddag, error) {
 	log.Debug().Msgf("Loading %v ...", filename)
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/gaddagmaker/make_gaddag.go
+++ b/gaddagmaker/make_gaddag.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/domino14/macondo/cache"
 	"github.com/rs/zerolog/log"
 
 	"github.com/domino14/macondo/alphabet"
@@ -74,7 +75,7 @@ func (a ArcPtrSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ArcPtrSlice) Less(i, j int) bool { return a[i].letter < a[j].letter }
 
 func getWordsFromFile(filename string) ([]string, *alphabet.Alphabet) {
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		log.Warn().Msgf("Filename %v not found", filename)
 		return nil, nil
@@ -434,7 +435,7 @@ func genGaddag(stream io.Reader, lexName string, minimize bool, writeToFile bool
 // GenerateGaddag makes a GADDAG out of the filename, and optionally
 // minimizes it and/or writes it to file.
 func GenerateGaddag(filename string, minimize bool, writeToFile bool) *Gaddag {
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		log.Warn().Msgf("Filename %v not found", filename)
 		return nil

--- a/gcgio/gcg.go
+++ b/gcgio/gcg.go
@@ -7,12 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/domino14/macondo/alphabet"
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/config"
 
 	"github.com/domino14/macondo/game"
@@ -520,7 +520,7 @@ func ParseGCGFromReader(cfg *config.Config, reader io.Reader) (*pb.GameHistory, 
 
 // ParseGCG parses a GCG file into a GameHistory.
 func ParseGCG(cfg *config.Config, filename string) (*pb.GameHistory, error) {
-	f, err := os.Open(filename)
+	f, err := cache.Open(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/gcgio/gcg_test.go
+++ b/gcgio/gcg_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/domino14/macondo/alphabet"
 	"github.com/domino14/macondo/board"
+	"github.com/domino14/macondo/cache"
 	"github.com/domino14/macondo/config"
 	"github.com/domino14/macondo/gaddagmaker"
 	"github.com/domino14/macondo/game"
@@ -38,7 +39,7 @@ func TestMain(m *testing.M) {
 }
 
 func slurp(filename string) string {
-	file, err := os.Open(filename)
+	file, err := cache.Open(filename)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/strategy/loaders.go
+++ b/strategy/loaders.go
@@ -3,12 +3,13 @@ package strategy
 import (
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/alecthomas/mph"
+	"github.com/domino14/macondo/cache"
 	"github.com/rs/zerolog/log"
 )
 
@@ -17,11 +18,11 @@ const (
 	PEGAdjustmentFilename = "preendgame.json"
 )
 
-func stratFileForLexicon(strategyDir string, filename string, lexiconName string) (*os.File, error) {
-	file, err := os.Open(filepath.Join(strategyDir, lexiconName, filename))
+func stratFileForLexicon(strategyDir string, filename string, lexiconName string) (io.ReadCloser, error) {
+	file, err := cache.Open(filepath.Join(strategyDir, lexiconName, filename))
 	if err != nil {
 		defdir := defaultForLexicon(lexiconName)
-		file, err = os.Open(filepath.Join(strategyDir, defdir, filename))
+		file, err = cache.Open(filepath.Join(strategyDir, defdir, filename))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
usage: simply precache before the file open attempt, for all files that may be opened.

```go
b, err := ioutil.ReadFile("data/letterdistributions/english.csv")
if err != nil { ... }
cache.Precache("data/letterdistributions/english.csv", b)
```

`cache.Open` behaves like `os.Open`, except if the file content is pre-cached it would just return that.

the path being precached must match the eventual `cache.Open("data/letterdistributions/english.csv")`, so avoid `cfg.AdjustRelativePaths`.