### PR TITLE
do not pad analyzer moves

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -150,7 +150,7 @@ func (an *Analyzer) Analyze(jsonBoard []byte) ([]byte, error) {
 		return nil, err
 	}
 	moves := an.game.GenerateMoves(15)
-	out := make([]JsonMove, 15)
+	out := make([]JsonMove, len(moves))
 	for i, m := range moves {
 		out[i] = MakeJsonMove(m)
 	}


### PR DESCRIPTION
return a shorter array if there are fewer than 15 options