### PR TITLE
possible endgame fix

### DIFF
--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -450,7 +450,7 @@ func (s *Solver) alphabeta(node *GameNode, depth int, α float32, β float32,
 	maximizingPlayer bool) *GameNode {
 
 	// depthDbg := strings.Repeat(" ", depth)
-	if depth == 0 || s.game.Playing() == pb.PlayState_GAME_OVER {
+	if depth == 0 || s.game.Playing() != pb.PlayState_PLAYING {
 		// s.game.Playing() happens if the game is over; i.e. if the
 		// current node is terminal.
 		node.calculateValue(s)

--- a/endgame/alphabeta/gamenode.go
+++ b/endgame/alphabeta/gamenode.go
@@ -98,7 +98,7 @@ func (g *GameNode) calculateValue(s *Solver) {
 		initialSpread = -initialSpread
 		negateHeurVal = true
 	}
-	gameOver := s.game.Playing() == pb.PlayState_GAME_OVER
+	gameOver := s.game.Playing() != pb.PlayState_PLAYING
 	// If the game is over, the value should just be the spread change.
 	if gameOver {
 		// Technically no one is on turn, but the player NOT on turn is


### PR DESCRIPTION
this may or may not fix 2df21b1f167bb45a4d129a965f16d6846f951eac and #119

i can't test it, but eyeballing the commit showed that `!s.game.Playing()` wasn't translated to `s.game.Playing() != game.StatePlaying` and there's `StateWaitingForFinalPass`. (i'm only changing the condition within alphabeta/)

```
-    if depth == 0 || !s.game.Playing() {
+    if depth == 0 || s.game.Playing() == game.StateGameOver {
```