### PR TITLE
draw randomly

### DIFF
--- a/alphabet/bag.go
+++ b/alphabet/bag.go
@@ -53,18 +53,27 @@ func (b *Bag) DrawAtMost(n int) []MachineLetter {
 	return drawn
 }
 
-// FastDraw draws n preshuffled tiles from the bag. Not all bag sequences may be possible.
+// FastDraw draws n random tiles from the bag. Shuffling is immaterial.
 func (b *Bag) FastDraw(n int) ([]MachineLetter, error) {
 	if n > len(b.tiles) {
 		return nil, fmt.Errorf("tried to draw %v tiles, tile bag has %v",
 			n, len(b.tiles))
 	}
-	drawn := make([]MachineLetter, n)
-	for i := 0; i < n; i++ {
-		drawn[i] = b.tiles[i]
-		b.tileMap[drawn[i]]--
+	// first shuffle the tiles in-place although frand does not error
+	l := len(b.tiles)
+	k := l - n
+	for i := l; i > k; i-- {
+		xi := frand.Intn(i)
+		// move the selected tile to the end
+		b.tiles[i-1], b.tiles[xi] = b.tiles[xi], b.tiles[i-1]
 	}
-	b.tiles = b.tiles[n:]
+	// now update tileMap
+	drawn := make([]MachineLetter, n)
+	copy(drawn, b.tiles[k:l])
+	for _, v := range drawn {
+		b.tileMap[v]--
+	}
+	b.tiles = b.tiles[:k]
 	// log.Debug().Int("numtiles", len(b.tiles)).Int("drew", n).Msg("drew from bag")
 	return drawn, nil
 }

--- a/alphabet/bag.go
+++ b/alphabet/bag.go
@@ -35,6 +35,15 @@ func (b *Bag) Refill() {
 	b.Shuffle()
 }
 
+// FastDrawAtMost is DrawAtMost using FastDraw.
+func (b *Bag) FastDrawAtMost(n int) []MachineLetter {
+	if n > len(b.tiles) {
+		n = len(b.tiles)
+	}
+	drawn, _ := b.FastDraw(n)
+	return drawn
+}
+
 // DrawAtMost draws at most n tiles from the bag. It can draw fewer if there
 // are fewer tiles than n, and even draw no tiles at all :o
 func (b *Bag) DrawAtMost(n int) []MachineLetter {
@@ -104,6 +113,17 @@ func (b *Bag) Shuffle() {
 	b.randSource.Shuffle(len(b.tiles), func(i, j int) {
 		b.tiles[i], b.tiles[j] = b.tiles[j], b.tiles[i]
 	})
+}
+
+// FastExchange is Exchange using FastDraw.
+func (b *Bag) FastExchange(letters []MachineLetter) ([]MachineLetter, error) {
+	newTiles, err := b.FastDraw(len(letters))
+	if err != nil {
+		return nil, err
+	}
+	// put exchanged tiles back into the bag and re-shuffle
+	b.PutBack(letters)
+	return newTiles, nil
 }
 
 // Exchange exchanges the junk in your rack with new tiles.
@@ -179,6 +199,12 @@ func (b *Bag) rebuildTileSlice(numTilesInBag int) error {
 	}
 	b.Shuffle()
 	return nil
+}
+
+// FastRedraw is Redraw using FastDraw.
+func (b *Bag) FastRedraw(currentRack []MachineLetter) []MachineLetter {
+	b.PutBack(currentRack)
+	return b.FastDrawAtMost(7)
 }
 
 // Redraw is basically a do-over; throw the current rack in the bag

--- a/alphabet/bag_test.go
+++ b/alphabet/bag_test.go
@@ -1,16 +1,12 @@
 package alphabet
 
 import (
-	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/domino14/macondo/config"
 	"github.com/matryer/is"
 )
-
-var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 var DefaultConfig = config.DefaultConfig()
 
@@ -19,7 +15,7 @@ func TestBag(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bag := ld.MakeBag(randSource)
+	bag := ld.MakeBag()
 	if len(bag.tiles) != ld.numLetters {
 		t.Error("Tile bag and letter distribution do not match.")
 	}
@@ -49,7 +45,7 @@ func TestDraw(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bag := ld.MakeBag(randSource)
+	bag := ld.MakeBag()
 
 	letters, _ := bag.Draw(7)
 	if len(letters) != 7 {
@@ -65,7 +61,7 @@ func TestDrawAtMost(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bag := ld.MakeBag(randSource)
+	bag := ld.MakeBag()
 
 	for i := 0; i < 14; i++ {
 		letters, _ := bag.Draw(7)
@@ -99,7 +95,7 @@ func TestExchange(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bag := ld.MakeBag(randSource)
+	bag := ld.MakeBag()
 
 	letters, _ := bag.Draw(7)
 	newLetters, _ := bag.Exchange(letters[:5])
@@ -113,7 +109,7 @@ func TestRemoveTiles(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bag := ld.MakeBag(randSource)
+	bag := ld.MakeBag()
 	is.Equal(len(bag.tiles), 100)
 	toRemove := []MachineLetter{
 		9, 14, 24, 4, 3, 20, 4, 11, 21, 6, 22, 14, 8, 0, 8, 15, 6, 5, 4,

--- a/alphabet/letter_distribution.go
+++ b/alphabet/letter_distribution.go
@@ -3,7 +3,6 @@ package alphabet
 import (
 	"encoding/csv"
 	"io"
-	"math/rand"
 	"strconv"
 
 	"github.com/domino14/macondo/config"
@@ -124,9 +123,9 @@ func (ld *LetterDistribution) NumTotalTiles() int {
 }
 
 // MakeBag returns a bag of tiles.
-func (ld *LetterDistribution) MakeBag(randSource *rand.Rand) *Bag {
+func (ld *LetterDistribution) MakeBag() *Bag {
 
-	b := NewBag(ld, ld.alph, randSource)
+	b := NewBag(ld, ld.alph)
 	b.Shuffle()
 
 	return b

--- a/game/backup.go
+++ b/game/backup.go
@@ -4,7 +4,6 @@ import (
 	"github.com/domino14/macondo/alphabet"
 	"github.com/domino14/macondo/board"
 	pb "github.com/domino14/macondo/gen/api/proto/macondo"
-	"github.com/rs/zerolog/log"
 )
 
 type BackupMode int
@@ -97,7 +96,7 @@ func (g *Game) SetStateStackLength(length int) {
 		// allocations and GC.
 		g.stateStack[idx] = &stateBackup{
 			board:          g.board.Copy(),
-			bag:            g.bag.Copy(nil),
+			bag:            g.bag.Copy(),
 			playing:        g.playing,
 			scorelessTurns: g.scorelessTurns,
 			players:        copyPlayers(g.players),
@@ -152,18 +151,14 @@ func (g *Game) ResetToFirstState() {
 // alphabet are not deep-copied because these are not expected to change.
 // The history is not copied because this only changes with the main Game,
 // and not these copies.
-// The bag is copied with a NEW random source, as random sources are not thread-safe.
 func (g *Game) Copy() *Game {
-
-	randSeed, randSource := seededRandSource()
-	log.Debug().Msgf("Created new random seed for bag copy %v", randSeed)
 
 	copy := &Game{
 		config:         g.config,
 		onturn:         g.onturn,
 		turnnum:        g.turnnum,
 		board:          g.board.Copy(),
-		bag:            g.bag.Copy(randSource),
+		bag:            g.bag.Copy(),
 		lexicon:        g.lexicon,
 		crossSetGen:    g.crossSetGen,
 		alph:           g.alph,

--- a/game/game.go
+++ b/game/game.go
@@ -363,7 +363,7 @@ func convertToVisible(words []alphabet.MachineWord,
 // gameplay engines as much as possible.
 // If the millis argument is passed in, it adds this value to the history
 // as the time remaining for the user (when they played the move).
-// FastPlayMove is the same but using a faster and less fair drawing algorithm.
+// FastPlayMove is the same but using a faster drawing algorithm.
 // They both call this function with different useFastDraw constants.
 func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw bool) error {
 
@@ -500,12 +500,12 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw
 	return nil
 }
 
-// FastPlayMove is playMove using FastDraw. Draws faster.
+// FastPlayMove is playMove using FastDraw. Draws using a faster userspace CSPRNG.
 func (g *Game) FastPlayMove(m *move.Move, addToHistory bool, millis int) error {
 	return g.playMove(m, addToHistory, millis, true)
 }
 
-// PlayMove is playMove. Draws fairer.
+// PlayMove is playMove. Draws using golang's slow CSPRNG.
 func (g *Game) PlayMove(m *move.Move, addToHistory bool, millis int) error {
 	return g.playMove(m, addToHistory, millis, false)
 }

--- a/game/game.go
+++ b/game/game.go
@@ -197,7 +197,7 @@ func NewFromHistory(history *pb.GameHistory, rules *GameRules, turnnum int) (*Ga
 	// Initialize the bag and player rack structures to avoid panics.
 	game.randSeed, game.randSource = seededRandSource()
 	log.Debug().Msgf("History - Random seed for this game was %v", game.randSeed)
-	game.bag = game.letterDistribution.MakeBag(game.randSource)
+	game.bag = game.letterDistribution.MakeBag()
 	for i := 0; i < game.NumPlayers(); i++ {
 		game.players[i].rack = alphabet.NewRack(game.alph)
 	}
@@ -221,7 +221,7 @@ func (g *Game) StartGame() {
 	g.Board().Clear()
 	g.randSeed, g.randSource = seededRandSource()
 	log.Debug().Msgf("Random seed for this game was %v", g.randSeed)
-	g.bag = g.letterDistribution.MakeBag(g.randSource)
+	g.bag = g.letterDistribution.MakeBag()
 	var goesfirst int
 	if g.nextFirst == -1 {
 		goesfirst = g.randSource.Intn(2)

--- a/game/game.go
+++ b/game/game.go
@@ -3,11 +3,8 @@
 package game
 
 import (
-	crypto_rand "crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/rand"
 	"strings"
 
 	"github.com/domino14/macondo/alphabet"
@@ -19,6 +16,7 @@ import (
 	"github.com/domino14/macondo/move"
 	"github.com/lithammer/shortuuid"
 	"github.com/rs/zerolog/log"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -30,19 +28,6 @@ const (
 	ExchangeLimit = 7
 	RackTileLimit = 7
 )
-
-func seededRandSource() (int64, *rand.Rand) {
-	var b [8]byte
-	_, err := crypto_rand.Read(b[:])
-	if err != nil {
-		panic("cannot seed math/rand package with cryptographically secure random number generator")
-	}
-
-	randSeed := int64(binary.LittleEndian.Uint64(b[:]))
-	randSource := rand.New(rand.NewSource(randSeed))
-
-	return randSeed, randSource
-}
 
 // Game is the actual internal game structure that controls the entire
 // business logic of the game; drawing, making moves, etc. The two
@@ -61,9 +46,6 @@ type Game struct {
 	bag                *alphabet.Bag
 
 	playing pb.PlayState
-
-	randSeed   int64
-	randSource *rand.Rand
 
 	wentfirst      int
 	scorelessTurns int
@@ -195,8 +177,6 @@ func NewFromHistory(history *pb.GameHistory, rules *GameRules, turnnum int) (*Ga
 	}
 
 	// Initialize the bag and player rack structures to avoid panics.
-	game.randSeed, game.randSource = seededRandSource()
-	log.Debug().Msgf("History - Random seed for this game was %v", game.randSeed)
 	game.bag = game.letterDistribution.MakeBag()
 	for i := 0; i < game.NumPlayers(); i++ {
 		game.players[i].rack = alphabet.NewRack(game.alph)
@@ -219,12 +199,10 @@ func (g *Game) SetNextFirst(first int) {
 // to both players.
 func (g *Game) StartGame() {
 	g.Board().Clear()
-	g.randSeed, g.randSource = seededRandSource()
-	log.Debug().Msgf("Random seed for this game was %v", g.randSeed)
 	g.bag = g.letterDistribution.MakeBag()
 	var goesfirst int
 	if g.nextFirst == -1 {
-		goesfirst = g.randSource.Intn(2)
+		goesfirst = frand.Intn(2)
 		log.Debug().Msgf("randomly determined %v to go first", goesfirst)
 	} else {
 		goesfirst = g.nextFirst

--- a/game/game.go
+++ b/game/game.go
@@ -341,9 +341,7 @@ func convertToVisible(words []alphabet.MachineWord,
 // gameplay engines as much as possible.
 // If the millis argument is passed in, it adds this value to the history
 // as the time remaining for the user (when they played the move).
-// FastPlayMove is the same but using a faster drawing algorithm.
-// They both call this function with different useFastDraw constants.
-func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw bool) error {
+func (g *Game) PlayMove(m *move.Move, addToHistory bool, millis int) error {
 
 	// We need to handle challenges separately.
 	if m.Action() == move.MoveTypeChallenge {
@@ -377,12 +375,7 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw
 		if m.TilesPlayed() == 7 {
 			g.players[g.onturn].bingos++
 		}
-		var drew []alphabet.MachineLetter
-		if useFastDraw {
-			drew = g.bag.FastDrawAtMost(m.TilesPlayed())
-		} else {
-			drew = g.bag.DrawAtMost(m.TilesPlayed())
-		}
+		drew := g.bag.DrawAtMost(m.TilesPlayed())
 		tiles := append(drew, []alphabet.MachineLetter(m.Leave())...)
 		g.players[g.onturn].setRackTiles(tiles, g.alph)
 
@@ -441,13 +434,7 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw
 		}
 
 	case move.MoveTypeExchange:
-		var drew []alphabet.MachineLetter
-		var err error
-		if useFastDraw {
-			drew, err = g.bag.FastExchange([]alphabet.MachineLetter(m.Tiles()))
-		} else {
-			drew, err = g.bag.Exchange([]alphabet.MachineLetter(m.Tiles()))
-		}
+		drew, err := g.bag.Exchange([]alphabet.MachineLetter(m.Tiles()))
 		if err != nil {
 			return err
 		}
@@ -476,16 +463,6 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, useFastDraw
 	// log.Debug().Interface("history", g.history).Int("onturn", g.onturn).Int("turnnum", g.turnnum).
 	// 	Msg("newhist")
 	return nil
-}
-
-// FastPlayMove is playMove using FastDraw. Draws using a faster userspace CSPRNG.
-func (g *Game) FastPlayMove(m *move.Move, addToHistory bool, millis int) error {
-	return g.playMove(m, addToHistory, millis, true)
-}
-
-// PlayMove is playMove. Draws using golang's slow CSPRNG.
-func (g *Game) PlayMove(m *move.Move, addToHistory bool, millis int) error {
-	return g.playMove(m, addToHistory, millis, false)
 }
 
 // AddFinalScoresToHistory adds the final scores and winner to the history.
@@ -869,16 +846,6 @@ func (g *Game) SetRacksForBoth(racks []*alphabet.Rack) error {
 func (g *Game) ThrowRacksIn() {
 	g.players[0].throwRackIn(g.bag)
 	g.players[1].throwRackIn(g.bag)
-}
-
-// FastSetRandomRack is SetRandomRack using FastDraw.
-func (g *Game) FastSetRandomRack(playerIdx int) {
-	// log.Debug().Int("player", playerIdx).Str("rack", g.RackFor(playerIdx).TilesOn().UserVisible(g.alph)).
-	// 	Msg("setting random rack..")
-	tiles := g.bag.FastRedraw(g.RackFor(playerIdx).TilesOn())
-	g.players[playerIdx].setRackTiles(tiles, g.alph)
-	// log.Debug().Int("player", playerIdx).Str("newrack", g.players[playerIdx].rackLetters).
-	// 	Msg("set random rack")
 }
 
 // SetRandomRack sets the player's rack to a random rack drawn from the bag.

--- a/game/randomness_test.go
+++ b/game/randomness_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/matryer/is"
+	"lukechampine.com/frand"
 )
 
 func TestRandomFirst(t *testing.T) {
 	is := is.New(t)
 	counts := [2]int{0, 0}
 	for i := 0; i < 100000; i++ {
-		_, source := seededRandSource()
-		selection := source.Intn(2)
+		selection := frand.Intn(2)
 		counts[selection]++
 	}
 	fmt.Println(counts)

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
+	lukechampine.com/frand v1.4.1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
+github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/alecthomas/mph v0.0.0-20190930022807-712982e3d8a2 h1:3QU1afrYIAZZo5tf7/O7DAOUNn05wlxHZoB9YSXVg08=
 github.com/alecthomas/mph v0.0.0-20190930022807-712982e3d8a2/go.mod h1:HX5roj0AK3pjtDnP4HIV4zY4yW56odJ0LEwgoHL8NLI=
 github.com/alecthomas/unsafeslice v0.1.0 h1:bZlgt0CcjLz1OxjIS//2B5MTfifcGPKmkzvQ7OarOvg=
@@ -121,6 +123,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -178,3 +181,5 @@ gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+lukechampine.com/frand v1.4.1 h1:L4l4KVKu0kRfAEiz/b9/xQbc4bycSD+UFjzh4E8q7lE=
+lukechampine.com/frand v1.4.1/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dtj3s=

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -319,7 +319,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 	// Give opponent a random rack from the bag. Note that this also
 	// shuffles the bag!
 	opp := (s.initialPlayer + 1) % s.gameCopies[thread].NumPlayers()
-	s.gameCopies[thread].FastSetRandomRack(opp)
+	s.gameCopies[thread].SetRandomRack(opp)
 	logIter := LogIteration{Iteration: iterationCount, Plays: []LogPlay{}, Thread: thread}
 
 	var logPlay LogPlay
@@ -338,7 +338,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 		// log.Debug().Msgf("Playing move %v", play)'
 		// Set the backup mode to simulation mode only to back up the first move:
 		s.gameCopies[thread].SetBackupMode(game.SimulationMode)
-		s.gameCopies[thread].FastPlayMove(simmedPlay.play, false, 0)
+		s.gameCopies[thread].PlayMove(simmedPlay.play, false, 0)
 		s.gameCopies[thread].SetBackupMode(game.NoBackup)
 		// Further plies will NOT be backed up.
 		for ply := 0; ply < plies; ply++ {
@@ -349,7 +349,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 
 				bestPlay := s.bestStaticTurn(onTurn, thread)
 				// log.Debug().Msgf("Ply %v, Best play: %v", ply+1, bestPlay)
-				s.gameCopies[thread].FastPlayMove(bestPlay, false, 0)
+				s.gameCopies[thread].PlayMove(bestPlay, false, 0)
 				// log.Debug().Msgf("Score is now %v", s.game.Score())
 				if s.logStream != nil {
 					plyChild = LogPlay{Play: bestPlay.ShortDescription(), Rack: bestPlay.FullRack(), Pts: bestPlay.Score()}

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -319,7 +319,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 	// Give opponent a random rack from the bag. Note that this also
 	// shuffles the bag!
 	opp := (s.initialPlayer + 1) % s.gameCopies[thread].NumPlayers()
-	s.gameCopies[thread].SetRandomRack(opp)
+	s.gameCopies[thread].FastSetRandomRack(opp)
 	logIter := LogIteration{Iteration: iterationCount, Plays: []LogPlay{}, Thread: thread}
 
 	var logPlay LogPlay
@@ -338,7 +338,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 		// log.Debug().Msgf("Playing move %v", play)'
 		// Set the backup mode to simulation mode only to back up the first move:
 		s.gameCopies[thread].SetBackupMode(game.SimulationMode)
-		s.gameCopies[thread].PlayMove(simmedPlay.play, false, 0)
+		s.gameCopies[thread].FastPlayMove(simmedPlay.play, false, 0)
 		s.gameCopies[thread].SetBackupMode(game.NoBackup)
 		// Further plies will NOT be backed up.
 		for ply := 0; ply < plies; ply++ {
@@ -349,7 +349,7 @@ func (s *Simmer) simSingleIteration(plies, thread, iterationCount int, logChan c
 
 				bestPlay := s.bestStaticTurn(onTurn, thread)
 				// log.Debug().Msgf("Ply %v, Best play: %v", ply+1, bestPlay)
-				s.gameCopies[thread].PlayMove(bestPlay, false, 0)
+				s.gameCopies[thread].FastPlayMove(bestPlay, false, 0)
 				// log.Debug().Msgf("Score is now %v", s.game.Score())
 				if s.logStream != nil {
 					plyChild = LogPlay{Play: bestPlay.ShortDescription(), Rack: bestPlay.FullRack(), Pts: bestPlay.Score()}

--- a/not-wasm/newleaves/exhaustive_leave_test.go
+++ b/not-wasm/newleaves/exhaustive_leave_test.go
@@ -2,12 +2,10 @@ package newleaves
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/domino14/macondo/alphabet"
 	"github.com/domino14/macondo/board"
@@ -83,9 +81,8 @@ func TestEndgameTiming(t *testing.T) {
 	oppRack := alphabet.NewRack(alph)
 	oppRack.Set(tilesInPlay.Rack1)
 	assert.Equal(t, oppRack.NumTiles(), uint8(2))
-	var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	bag := alphabet.NewBag(ld, alph, randSource)
+	bag := alphabet.NewBag(ld, alph)
 	bag.Draw(100)
 
 	plays := generator.Plays()
@@ -120,9 +117,7 @@ func TestPreendgameTiming(t *testing.T) {
 	els, err := strategy.NewExhaustiveLeaveStrategy("NWL18", alph, &DefaultConfig, "", "quackle_preendgame.json")
 	assert.Nil(t, err)
 
-	var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	bag := alphabet.NewBag(ld, alph, randSource)
+	bag := alphabet.NewBag(ld, alph)
 	bag.RemoveTiles(tilesInPlay.OnBoard)
 	bag.RemoveTiles(tilesInPlay.Rack1)
 	bag.RemoveTiles(tilesInPlay.Rack2)

--- a/strategy/exhaustive_leave_test.go
+++ b/strategy/exhaustive_leave_test.go
@@ -1,12 +1,10 @@
 package strategy
 
 import (
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/domino14/macondo/alphabet"
 	"github.com/domino14/macondo/board"
@@ -81,9 +79,8 @@ func TestEndgameTiming(t *testing.T) {
 	oppRack := alphabet.NewRack(alph)
 	oppRack.Set(tilesInPlay.Rack1)
 	assert.Equal(t, oppRack.NumTiles(), uint8(2))
-	var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	bag := alphabet.NewBag(ld, alph, randSource)
+	bag := alphabet.NewBag(ld, alph)
 	bag.Draw(100)
 
 	plays := generator.Plays()
@@ -118,9 +115,7 @@ func TestPreendgameTiming(t *testing.T) {
 	els, err := NewExhaustiveLeaveStrategy("NWL18", alph, &DefaultConfig, "", "quackle_preendgame.json")
 	assert.Nil(t, err)
 
-	var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	bag := alphabet.NewBag(ld, alph, randSource)
+	bag := alphabet.NewBag(ld, alph)
 	bag.RemoveTiles(tilesInPlay.OnBoard)
 	bag.RemoveTiles(tilesInPlay.Rack1)
 	bag.RemoveTiles(tilesInPlay.Rack2)


### PR DESCRIPTION
address some FUDs mentioned in #125

- crypto/rand one-at-a-time by default
- frand one-at-a-time for simming (not configurable, it's hardcoded)
- frand for shuffling; remove randSource from Bag
- frand for "who starts"; remove randSeed, randSource from Game
- shuffling is still done but no longer affects actual tile drawing order, maybe can remove