### PR TITLE
remove alternate first logic

### DIFF
--- a/gcgio/gcg.go
+++ b/gcgio/gcg.go
@@ -171,7 +171,6 @@ func (p *parser) addEventOrPragma(cfg *config.Config, token Token, match []strin
 			if err != nil {
 				return err
 			}
-			p.game.SetNextFirst(0)
 			p.game.StartGame()
 			p.game.SetBackupMode(game.InteractiveGameplayMode)
 			p.game.SetStateStackLength(1)

--- a/runner/cross_set_test.go
+++ b/runner/cross_set_test.go
@@ -55,9 +55,7 @@ type testMove struct {
 
 func TestCompareGameMove(t *testing.T) {
 	opts := &GameOptions{
-		FirstIsAssigned: true,
-		GoesFirst:       0,
-		ChallengeRule:   pb.ChallengeRule_SINGLE,
+		ChallengeRule: pb.ChallengeRule_SINGLE,
 	}
 	players := []*pb.PlayerInfo{
 		{Nickname: "JD", RealName: "Jesse"},

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -21,12 +21,7 @@ func NewGameRunnerFromRules(opts *GameOptions, players []*pb.PlayerInfo, rules *
 	if err != nil {
 		return nil, err
 	}
-	if opts.FirstIsAssigned {
-		g.SetNextFirst(opts.GoesFirst)
-	} else {
-		// game determines it.
-		g.SetNextFirst(-1)
-	}
+
 	g.StartGame()
 	g.SetBackupMode(game.InteractiveGameplayMode)
 	g.SetStateStackLength(1)

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -22,8 +22,6 @@ func (lex *Lexicon) ToDisplayString() string {
 type GameOptions struct {
 	Lexicon         *Lexicon
 	ChallengeRule   pb.ChallengeRule
-	FirstIsAssigned bool
-	GoesFirst       int
 	BoardLayoutName string
 }
 

--- a/shell/api.go
+++ b/shell/api.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"lukechampine.com/frand"
 
 	airunner "github.com/domino14/macondo/ai/runner"
 	"github.com/domino14/macondo/automatic"
@@ -59,6 +60,9 @@ func (sc *ShellController) newGame(cmd *shellcmd) (*Response, error) {
 	players := []*pb.PlayerInfo{
 		{Nickname: "arcadio", RealName: "José Arcadio Buendía"},
 		{Nickname: "úrsula", RealName: "Úrsula Iguarán Buendía"},
+	}
+	if frand.Intn(2) == 1 {
+		players[0], players[1] = players[1], players[0]
 	}
 
 	opts := sc.options.GameOptions


### PR DESCRIPTION
Remove all logic that assigns firsts and seconds (and flips players accordingly). Let's make the caller the one that determines who goes first and second by passing the players array in the correct order.