### PR TITLE
remove nickname entirely from events

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -142,10 +142,6 @@ func (bot *Bot) evaluationResponse(req *pb.EvaluationRequest) *pb.BotResponse {
 
 	for idx, evt := range evts {
 		evtNickname := players[evt.PlayerIndex].Nickname
-		if evt.Nickname != "" {
-			// remove -- deprecated
-			evtNickname = evt.Nickname
-		}
 		userMatches := strings.EqualFold(evtNickname, req.User)
 		if userMatches && (evt.Type == pb.GameEvent_TILE_PLACEMENT_MOVE || evt.Type == pb.GameEvent_EXCHANGE) {
 			eval := evalSingleMove(bot.game, idx)

--- a/game/challenge.go
+++ b/game/challenge.go
@@ -45,8 +45,6 @@ func (g *Game) ChallengeEvent(addlBonus int, millis int) (bool, error) {
 	challengee := otherPlayer(g.onturn)
 
 	offBoardEvent := &pb.GameEvent{
-		// XXX: Deprecate nickname after deploy.
-		Nickname:    lastEvent.Nickname,
 		PlayerIndex: lastEvent.PlayerIndex,
 		Type:        pb.GameEvent_PHONY_TILES_RETURNED,
 		LostScore:   lastEvent.Score,
@@ -133,8 +131,6 @@ func (g *Game) ChallengeEvent(addlBonus int, millis int) (bool, error) {
 
 		bonusScoreEvent := func(bonus int32) *pb.GameEvent {
 			return &pb.GameEvent{
-				// XXX: Deprecate nickname after deploy.
-				Nickname:    lastEvent.Nickname,
 				PlayerIndex: lastEvent.PlayerIndex,
 				Type:        pb.GameEvent_CHALLENGE_BONUS,
 				Rack:        g.players[challengee].rackLetters,

--- a/game/game.go
+++ b/game/game.go
@@ -766,21 +766,6 @@ func (g *Game) playTurn(t int) error {
 	log.Trace().Int("event-type", int(evt.Type)).Int("turn", t).Msg("playTurn")
 	g.onturn = int(evt.PlayerIndex)
 
-	if evt.Nickname != "" {
-		log.Warn().Msg("evt.Nickname is deprecated; do not use")
-		found := false
-		for idx, p := range g.players {
-			if p.Nickname == evt.Nickname {
-				g.onturn = idx
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("player not found: %v", evt.Nickname)
-		}
-	}
-
 	m, err := MoveFromEvent(evt, g.alph, g.board)
 	if err != nil {
 		return err

--- a/game/turn.go
+++ b/game/turn.go
@@ -23,8 +23,6 @@ func (g *Game) EventFromMove(m *move.Move) *pb.GameEvent {
 	curPlayer := g.curPlayer()
 
 	evt := &pb.GameEvent{
-		// XXX: Remove after deploy
-		Nickname:    curPlayer.Nickname,
 		PlayerIndex: uint32(g.onturn),
 		Cumulative:  int32(curPlayer.points),
 		Rack:        m.FullRack(),
@@ -67,7 +65,6 @@ func (g *Game) endRackEvt(pidx int, bonusPts int) *pb.GameEvent {
 	otherPlayer := g.players[otherPlayer(pidx)]
 
 	evt := &pb.GameEvent{
-		Nickname:      curPlayer.Nickname,
 		PlayerIndex:   uint32(pidx),
 		Cumulative:    int32(curPlayer.points),
 		Rack:          otherPlayer.rack.String(),
@@ -81,7 +78,6 @@ func (g *Game) endRackPenaltyEvt(penalty int) *pb.GameEvent {
 	curPlayer := g.curPlayer()
 
 	evt := &pb.GameEvent{
-		Nickname:    curPlayer.Nickname,
 		PlayerIndex: uint32(g.onturn),
 		Cumulative:  int32(curPlayer.points),
 		Rack:        curPlayer.rack.String(),

--- a/game/turn_test.go
+++ b/game/turn_test.go
@@ -40,7 +40,6 @@ func TestEventFromMove(t *testing.T) {
 	evt := g.EventFromMove(m)
 
 	is.Equal(evt, &pb.GameEvent{
-		Nickname:    "botty",
 		Cumulative:  0,
 		Rack:        "?EGKMNO",
 		Exchanged:   "?EGKMNO",


### PR DESCRIPTION
Remove fallback. This is fine because liwords is single-server and upon redeploy, we would reload games using new schemas, so this doesn't need the old schema.