### PR TITLE
re-add old checks for obsoleted fields

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -142,6 +142,10 @@ func (bot *Bot) evaluationResponse(req *pb.EvaluationRequest) *pb.BotResponse {
 
 	for idx, evt := range evts {
 		evtNickname := players[evt.PlayerIndex].Nickname
+		if evt.Nickname != "" {
+			// remove -- deprecated
+			evtNickname = evt.Nickname
+		}
 		userMatches := strings.EqualFold(evtNickname, req.User)
 		if userMatches && (evt.Type == pb.GameEvent_TILE_PLACEMENT_MOVE || evt.Type == pb.GameEvent_EXCHANGE) {
 			eval := evalSingleMove(bot.game, idx)

--- a/game/game.go
+++ b/game/game.go
@@ -772,6 +772,21 @@ func (g *Game) playTurn(t int) error {
 	log.Trace().Int("event-type", int(evt.Type)).Int("turn", t).Msg("playTurn")
 	g.onturn = int(evt.PlayerIndex)
 
+	if evt.Nickname != "" {
+		// This is deprecated -- remove
+		found := false
+		for idx, p := range g.players {
+			if p.Nickname == evt.Nickname {
+				g.onturn = idx
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("player not found: %v", evt.Nickname)
+		}
+	}
+
 	m, err := MoveFromEvent(evt, g.alph, g.board)
 	if err != nil {
 		return err

--- a/game/turn.go
+++ b/game/turn.go
@@ -23,6 +23,8 @@ func (g *Game) EventFromMove(m *move.Move) *pb.GameEvent {
 	curPlayer := g.curPlayer()
 
 	evt := &pb.GameEvent{
+		// XXX: Remove
+		Nickname:    curPlayer.Nickname,
 		PlayerIndex: uint32(g.onturn),
 		Cumulative:  int32(curPlayer.points),
 		Rack:        m.FullRack(),
@@ -65,6 +67,8 @@ func (g *Game) endRackEvt(pidx int, bonusPts int) *pb.GameEvent {
 	otherPlayer := g.players[otherPlayer(pidx)]
 
 	evt := &pb.GameEvent{
+		// remove
+		Nickname:      curPlayer.Nickname,
 		PlayerIndex:   uint32(pidx),
 		Cumulative:    int32(curPlayer.points),
 		Rack:          otherPlayer.rack.String(),
@@ -78,6 +82,8 @@ func (g *Game) endRackPenaltyEvt(penalty int) *pb.GameEvent {
 	curPlayer := g.curPlayer()
 
 	evt := &pb.GameEvent{
+		// XXX remove
+		Nickname:    curPlayer.Nickname,
 		PlayerIndex: uint32(g.onturn),
 		Cumulative:  int32(curPlayer.points),
 		Rack:        curPlayer.rack.String(),

--- a/game/turn_test.go
+++ b/game/turn_test.go
@@ -40,6 +40,7 @@ func TestEventFromMove(t *testing.T) {
 	evt := g.EventFromMove(m)
 
 	is.Equal(evt, &pb.GameEvent{
+		Nickname:    "botty",
 		Cumulative:  0,
 		Rack:        "?EGKMNO",
 		Exchanged:   "?EGKMNO",


### PR DESCRIPTION
### Motivation

The bot is currently broken in the master version of Macondo when used with the master version of liwords. This PR re-adds a fallback to the old protobuf fields, so that we unbreak the bot. We can then do the liwords migration afterwards.