### PR TITLE
use sync.Pool only with pointer type

### DIFF
--- a/gaddag/lexicon.go
+++ b/gaddag/lexicon.go
@@ -21,14 +21,14 @@ func (l Lexicon) HasWord(word alphabet.MachineWord) bool {
 
 var daPool = sync.Pool{
 	New: func() interface{} {
-		return DawgAnagrammer{}
+		return &DawgAnagrammer{}
 	},
 }
 
 func (l Lexicon) HasAnagram(word alphabet.MachineWord) bool {
 	log.Debug().Str("word", word.UserVisible(l.GetAlphabet())).Msg("has-anagram?")
 
-	da := daPool.Get().(DawgAnagrammer)
+	da := daPool.Get().(*DawgAnagrammer)
 	defer daPool.Put(da)
 
 	v, err := da.IsValidJumble(l, word)


### PR DESCRIPTION
fixes `argument should be pointer-like to avoid allocations (SA6002)` reported by [staticcheck](https://staticcheck.io/docs/checks/#SA6002)

parent commit is 0d341fa98a4de417dd8642011c666c8aa487a5e4 for most flexibility