### PR TITLE
fix betterbot not knowing how to exchange

### DIFF
--- a/ai/runner/filters.go
+++ b/ai/runner/filters.go
@@ -24,7 +24,7 @@ var BotConfigs = map[pb.BotRequest_BotCode]struct {
 	pb.BotRequest_LEVEL1_CEL_BOT: {baseFindability: 0.3, longWordFindability: 0.1, parallelFindability: 0.3, isCel: true},
 	pb.BotRequest_LEVEL2_CEL_BOT: {baseFindability: 0.7, longWordFindability: 0.4, parallelFindability: 0.5, isCel: true},
 	pb.BotRequest_LEVEL3_CEL_BOT: {baseFindability: 0.8, longWordFindability: 0.5, parallelFindability: 0.75, isCel: true},
-	pb.BotRequest_LEVEL4_CEL_BOT: {isCel: true},
+	pb.BotRequest_LEVEL4_CEL_BOT: {baseFindability: 1.0, longWordFindability: 1.0, parallelFindability: 1.0, isCel: true},
 
 	pb.BotRequest_LEVEL1_PROBABILISTIC: {baseFindability: 0.2, longWordFindability: 0.07, parallelFindability: 0.15, isCel: false},
 	pb.BotRequest_LEVEL2_PROBABILISTIC: {baseFindability: 0.4, longWordFindability: 0.2, parallelFindability: 0.3, isCel: false},


### PR DESCRIPTION
possibly fix #171 

- BetterBot is `LEVEL4_CEL_BOT` in [liwords](https://github.com/domino14/liwords/blob/a6b6fd9d66f27687a2b6e4dba10bef588f3ba2ee/liwords-ui/src/lobby/bots.ts#L36-L44)

- `BotConfig[LEVEL4_CEL_BOT].baseFindability == 0.0` because that's the [zero value](https://go.dev/ref/spec#The_zero_value)

https://github.com/domino14/macondo/blob/0bf2464eb2b3e2a2b21f9d3d21e049303428c34b/ai/runner/filters.go#L16-L27

- if `r >= 0.0` exchanging is not allowed

https://github.com/domino14/macondo/blob/0bf2464eb2b3e2a2b21f9d3d21e049303428c34b/ai/runner/filters.go#L120-L125

- `r := frand.Float64()`, which means [r >= 0.0 is always true](https://pkg.go.dev/lukechampine.com/frand#Float64)

https://github.com/domino14/macondo/blob/0bf2464eb2b3e2a2b21f9d3d21e049303428c34b/ai/runner/filters.go#L107