### PR TITLE
Format endgame variation using short description

### DIFF
--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -538,9 +538,11 @@ func (s *Solver) Solve(plies int) (float32, []*move.Move, error) {
 					bestV = bestNode.heuristicValue.value
 					bestSeq = s.findBestSequence(bestNode)
 
-					fmt.Printf("-- Spread swing estimate found after %d plies: %f\n",
-						p, bestV)
-					fmt.Printf("--> Best seq so far is %v\n\n", bestSeq)
+					fmt.Printf("-- Spread swing estimate found after %d plies: %f", p, bestV)
+					for idx, move := range bestSeq {
+						fmt.Printf(" %d) %v", idx+1, move.ShortDescription())
+					}
+					fmt.Printf("\n")
 				}
 			}
 		} else {


### PR DESCRIPTION
I find this easier to read, but perhaps in the future something more verbose is warranted.

```
-- Spread swing estimate found after 1 plies: 58.000000 1) 15H UPROsE
-- Spread swing estimate found after 2 plies: 2.000000 1)  1A POEM 2)  A4 .ONED
-- Spread swing estimate found after 3 plies: 35.000000 1)  K5 EM 2)  1A FOE 3) 15H POURs
-- Spread swing estimate found after 4 plies: 32.000000 1)  M3 EMO. 2)  1A FOE 3)  N2 sPUR
{"level":"info","time-elapsed-sec":37.083129972,"time":"2022-08-21T11:01:00-05:00","message":"solve-returning"}
Best sequence has a spread difference of 32
Best sequence:
1)  M3 EMO.
2)  1A FOE
3)  N2 sPUR
```