### PR TITLE
Sort endgame plays by alpha estimate

### DIFF
--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -236,7 +236,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	ld := s.game.Bag().LetterDistribution()
 
 	sideToMovePlays := s.stmMovegen.GenAll(stmRack, false)
-	if s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0 {
+	if stmRack.NumTiles() > 1 && (s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0) {
 		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
 		sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
 	}

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -240,14 +240,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
 		// Skip adding pass if player has an out play ("6-pass" scoring never outperforms an out play).
 		// This is more about "don't search a dubious pass subtree" than about memory allocation.
-		var out *move.Move
-		for _, m := range sideToMovePlays {
-			if m.TilesPlayed() == int(numTilesOnRack) {
-				out = m
-				break
-			}
-		}
-		if out == nil {
+		if !containsOutPlay(sideToMovePlays, int(numTilesOnRack)) {
 			sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
 		}
 	}
@@ -343,6 +336,15 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	// 	stmCopy[idx].CopyFrom(sideToMovePlays[idx])
 	// }
 	return sideToMovePlays
+}
+
+func containsOutPlay(plays []*move.Move, numTilesOnRack int) bool {
+	for _, m := range plays {
+		if m.TilesPlayed() == numTilesOnRack {
+			return true
+		}
+	}
+	return false
 }
 
 func movesMatch(t alphabet.MachineWord, lv alphabet.MachineWord, mm *minimalMove) bool {

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -236,7 +236,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	ld := s.game.Bag().LetterDistribution()
 
 	sideToMovePlays := s.stmMovegen.GenAll(stmRack, false)
-	if depth > 1 || (parent.move != nil && len(parent.move.tiles) == 0) {
+	if s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0 {
 		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
 		sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
 	}

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -235,12 +235,15 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	board := s.game.Board()
 	ld := s.game.Bag().LetterDistribution()
 
-	s.stmMovegen.GenAll(stmRack, false)
-	sideToMovePlays := s.addPass(s.stmMovegen.Plays(), s.game.PlayerOnTurn())
+	sideToMovePlays := s.stmMovegen.GenAll(stmRack, false)
+	if depth > 1 || (parent.move != nil && len(parent.move.tiles) == 0) {
+		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
+		sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
+	}
 	// log.Debug().Msgf("stm plays %v", sideToMovePlays)
 	if !s.complexEvaluation {
 		// Static evaluation must be fast and resource-efficient
-		for _, m := range s.stmMovegen.Plays() {
+		for _, m := range sideToMovePlays {
 			if depth > 2 {
 				m.SetValuation(float32(m.Score() + 3*m.TilesPlayed()))
 			} else if m.TilesPlayed() == int(numTilesOnRack) {

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -241,7 +241,11 @@ func (s *Solver) generateSTMPlays(parent *GameNode) []*move.Move {
 	if !s.complexEvaluation {
 		// Static evaluation must be fast and resource-efficient
 		for _, m := range s.stmMovegen.Plays() {
-			m.SetValuation(float32(m.Score() - 2*m.Leave().Score(ld)))
+			if m.TilesPlayed() == int(numTilesOnRack) {
+				m.SetValuation(float32(m.Score() + 2*otherRack.ScoreOn(ld)))
+			} else {
+				m.SetValuation(float32(m.Score() - 2*m.Leave().Score(ld)))
+			}
 		}
 		sort.Slice(sideToMovePlays, func(i, j int) bool {
 			return sideToMovePlays[i].Valuation() > sideToMovePlays[j].Valuation()

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -239,10 +239,9 @@ func (s *Solver) generateSTMPlays(parent *GameNode) []*move.Move {
 	sideToMovePlays := s.addPass(s.stmMovegen.Plays(), s.game.PlayerOnTurn())
 	// log.Debug().Msgf("stm plays %v", sideToMovePlays)
 	if !s.complexEvaluation {
-		// A simple evaluation function is a very dumb, but fast, function
-		// of score and tiles played. /shrug
+		// Static evaluation must be fast and resource-efficient
 		for _, m := range s.stmMovegen.Plays() {
-			m.SetValuation(float32(m.Score() + 3*m.TilesPlayed()))
+			m.SetValuation(float32(m.Score() - 2*m.Leave().Score(ld)))
 		}
 		sort.Slice(sideToMovePlays, func(i, j int) bool {
 			return sideToMovePlays[i].Valuation() > sideToMovePlays[j].Valuation()
@@ -250,6 +249,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode) []*move.Move {
 		return sideToMovePlays
 	}
 
+	// Dynamic evaluation sacrifices speed for accuracy
 	// log.Debug().Msgf("stm %v (%v), ots %v (%v)",
 	// 	s.game.PlayerOnTurn(), stmRack.String(), pnot, otherRack.String())
 	s.otsMovegen.SetSortingParameter(movegen.SortByScore)

--- a/endgame/alphabeta/gamenode.go
+++ b/endgame/alphabeta/gamenode.go
@@ -13,9 +13,7 @@ const PerTurnPenalty = float32(0.001)
 type nodeValue struct {
 	value          float32
 	sequenceLength uint8
-
-	knownEnd bool
-	isPass   bool
+	knownEnd       bool
 }
 
 func (nv *nodeValue) String() string {
@@ -38,14 +36,7 @@ func (nv *nodeValue) less(other *nodeValue) bool {
 		// i.e. known end > unknown end
 		return other.knownEnd
 	}
-	// Third tie-breaker is whether this is a pass or not.
-	if nv.isPass != other.isPass {
-		// we should rank non-passes higher than passes if everything else
-		// is equal.
-		// i.e. pass < not pass
-		return nv.isPass
-	}
-	// Fourth tie-breaker is length of sequence, favoring shorter sequences
+	// Third tie-breaker is length of sequence, favoring shorter sequences
 	return nv.sequenceLength > other.sequenceLength
 
 }
@@ -159,7 +150,6 @@ func (g *GameNode) calculateValue(s *Solver) {
 		g.heuristicValue = &nodeValue{
 			value:          float32(spreadNow - initialSpread),
 			knownEnd:       true,
-			isPass:         len(g.move.tiles) == 0,
 			sequenceLength: uint8(s.game.Turn() - s.initialTurnNum)}
 	} else {
 		// The valuation is already an estimate of the overall gain or loss
@@ -176,8 +166,7 @@ func (g *GameNode) calculateValue(s *Solver) {
 		g.heuristicValue = &nodeValue{
 			value:          float32(spreadNow) + moveVal - float32(initialSpread),
 			knownEnd:       false,
-			sequenceLength: uint8(s.game.Turn() - s.initialTurnNum),
-			isPass:         len(g.move.tiles) == 0}
+			sequenceLength: uint8(s.game.Turn() - s.initialTurnNum)}
 		// g.heuristicValue = s.game.EndgameSpreadEstimate(player, maximizing) - float32(initialSpread)
 		// log.Debug().Msgf("Calculating heuristic value of %v as %v - %v",
 		// 	g.move, s.game.EndgameSpreadEstimate(player), float32(initialSpread))

--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -30,7 +30,7 @@ const (
 
 // MoveGenerator is a generic interface for generating moves.
 type MoveGenerator interface {
-	GenAll(rack *alphabet.Rack, addExchange bool)
+	GenAll(rack *alphabet.Rack, addExchange bool) []*move.Move
 	SetSortingParameter(s SortBy)
 	Plays() []*move.Move
 	SetPlayRecorder(pf PlayRecorderFunc)
@@ -119,7 +119,7 @@ func (gen *GordonGenerator) SetGame(g *game.Game) {
 
 // GenAll generates all moves on the board. It assumes anchors have already
 // been updated, as well as cross-sets / cross-scores.
-func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) {
+func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) []*move.Move {
 	gen.winner.SetEmpty()
 
 	gen.plays = gen.plays[:0]
@@ -156,7 +156,7 @@ func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) {
 		// elsewhere (for example, a dedicated endgame engine)
 		break
 	}
-
+	return gen.plays;
 }
 
 func (gen *GordonGenerator) genByOrientation(rack *alphabet.Rack, dir board.BoardDirection) {


### PR DESCRIPTION
I assume attempting to play high-scoring tiles first is usually a good idea, since the final score is based upon stuck tiles.

EDIT: https://woogles.io/game/mQLyde5N?turn=27 solves 100% faster as well once `GenAll` returns `[]*move.Move`.