### PR TITLE
Endgame generate fewer passes

### DIFF
--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -236,7 +236,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	ld := s.game.Bag().LetterDistribution()
 
 	sideToMovePlays := s.stmMovegen.GenAll(stmRack, false)
-	if s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0 {
+	if stmRack.NumTiles() > 1 && (s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0) {
 		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
 		sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
 	}

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -236,7 +236,7 @@ func (s *Solver) generateSTMPlays(parent *GameNode, depth int) []*move.Move {
 	ld := s.game.Bag().LetterDistribution()
 
 	sideToMovePlays := s.stmMovegen.GenAll(stmRack, false)
-	if depth > 1 || (parent.move != nil && len(parent.move.tiles) == 0) {
+	if s.iterativeDeepeningOn || depth > 1 || parent.move == nil || len(parent.move.tiles) == 0 {
 		// If opponent just scored and depth is 1, "6-pass" scoring is not available.
 		sideToMovePlays = s.addPass(sideToMovePlays, s.game.PlayerOnTurn())
 	}

--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -30,7 +30,7 @@ const (
 
 // MoveGenerator is a generic interface for generating moves.
 type MoveGenerator interface {
-	GenAll(rack *alphabet.Rack, addExchange bool)
+	GenAll(rack *alphabet.Rack, addExchange bool) []*move.Move
 	SetSortingParameter(s SortBy)
 	Plays() []*move.Move
 	SetPlayRecorder(pf PlayRecorderFunc)
@@ -119,7 +119,7 @@ func (gen *GordonGenerator) SetGame(g *game.Game) {
 
 // GenAll generates all moves on the board. It assumes anchors have already
 // been updated, as well as cross-sets / cross-scores.
-func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) {
+func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) []*move.Move {
 	gen.winner.SetEmpty()
 
 	gen.plays = gen.plays[:0]
@@ -156,7 +156,7 @@ func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) {
 		// elsewhere (for example, a dedicated endgame engine)
 		break
 	}
-
+	return gen.plays;
 }
 
 func (gen *GordonGenerator) genByOrientation(rack *alphabet.Rack, dir board.BoardDirection) {


### PR DESCRIPTION
At the final ply of simulation, only allow a pass to be generated if the opponent just passed.

```
macondo> endgame -plies 14
plies 14, maxtime 0, maxnodes 0

   A B C D E F G H I J K L M N O                  wanderer15           365
   ------------------------------    ->            deldar182  EEILPT?  335
 1|=     '       =       '     = |
 2|  -       "       "       -   |   Bag + unseen: (6)
 3|    -       '   '     W -     |
 4|'     -       '   T O E D   ' |   D I L L S T
 5|        -       C O S M I C   |
 6|  "       "   O H M       R   |
 7|    '       '   ' E R   Q I N |
 8|=     '     V O X   U R I N E |
 9|    '       ' O U P A   ' G   |
10|  "       K A T   E N   Z E D |   Turn 27:
11|G       F A E   B H A J I   A |   wanderer15 played B12 R..D for 7 pts from
12|U R   G A E   ' R     E N   W |   a rack of DDILRST
13|V A U       '   R     A E   T |
14|  I g N O B L E   I O N   -   |
15|= D   Y O     S A T I S F Y = |
   ------------------------------

-- Spread swing estimate found after 1 plies: 30.000000 1)  M2 PE..
-- Spread swing estimate found after 2 plies: -2.000000 1)  M1 bEE.. 2)  3K D..LT
-- Spread swing estimate found after 3 plies: 34.000000 1)  4H vE.... 2)  I3 L... 3)  M2 PE..
-- Spread swing estimate found after 4 plies: 24.000000 1)  E7 TrEI.. 2)  D3 DILLS 3)  C2 LEP
-- Spread swing estimate found after 5 plies: 40.000000 1) 15A I. 2)  J1 DIS.... 3) 12L ..E. 4)  2I L.T 5)  1H PE.aL
-- Spread swing estimate found after 6 plies: 25.000000 1)  M2 PE.. 2)  N1 TID 3)  O1 ITs 4) 12K S.. 5) 15A E. 6) (Pass)
-- Spread swing estimate found after 7 plies: 43.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) N14 n. 6) (Pass) 7)  M2 PE..
-- Spread swing estimate found after 8 plies: 37.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) 13H o.T 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 9 plies: 37.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) 13H o.T 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 10 plies: 37.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) 13H o.T 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 11 plies: 37.000000 1) 15A I. 2) 12K S.. 3) 13H o.T 4) (Pass) 5)  6N .E 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 12 plies: 37.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) 13H o.T 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 13 plies: 37.000000 1) 15A I. 2) 12K S.. 3) 13H o.T 4) (Pass) 5)  6N .E 6) (Pass) 7)  J1 LEP....
-- Spread swing estimate found after 14 plies: 37.000000 1) 15A I. 2) 12K S.. 3)  6N .E 4) (Pass) 5) 13H o.T 6) (Pass) 7)  J1 LEP....
{"level":"info","time-elapsed-sec":50.498656194,"time":"2022-08-22T21:37:47-05:00","message":"solve-returning"}
Best sequence has a spread difference of 37
Best sequence:
1) 15A I.
2) 12K S..
3)  6N .E
4) (Pass)
5) 13H o.T
6) (Pass)
7)  J1 LEP....
```