### PR TITLE
Sort plays by score before adding exchanges

### DIFF
--- a/movegen/movegen.go
+++ b/movegen/movegen.go
@@ -141,22 +141,21 @@ func (gen *GordonGenerator) GenAll(rack *alphabet.Rack, addExchange bool) {
 		tilesOnRack := rack.TilesOn()
 		passMove := move.NewPassMove(tilesOnRack, rack.Alphabet())
 		gen.plays = append(gen.plays, passMove)
+	} else if len(gen.plays) > 1 {
+		switch gen.sortingParameter {
+		case SortByScore:
+			sort.Slice(gen.plays, func(i, j int) bool {
+				return gen.plays[i].Score() > gen.plays[j].Score()
+			})
+		case SortByNone:
+			// Do not sort the plays. It is assumed that we will sort plays
+			// elsewhere (for example, a dedicated endgame engine)
+			break
+		}
 	}
 	if addExchange {
 		gen.generateExchangeMoves(rack, 0, 0)
 	}
-
-	switch gen.sortingParameter {
-	case SortByScore:
-		sort.Slice(gen.plays, func(i, j int) bool {
-			return gen.plays[i].Score() > gen.plays[j].Score()
-		})
-	case SortByNone:
-		// Do not sort the plays. It is assumed that we will sort plays
-		// elsewhere (for example, a dedicated endgame engine)
-		break
-	}
-
 }
 
 func (gen *GordonGenerator) genByOrientation(rack *alphabet.Rack, dir board.BoardDirection) {


### PR DESCRIPTION
Play scores are whole numbers (non-negative) and exchange/pass scores are zero, so perhaps this sorts plays faster.