### PR TITLE
fix zobrist hash logic

### DIFF
--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -69,7 +69,7 @@ type Solver struct {
 	stmMovegen       movegen.MoveGenerator
 	otsMovegen       movegen.MoveGenerator
 	game             *game.Game
-	killerCache      map[uint64]string
+	killerCache      map[uint64]*move.Move
 	nodeCount        map[uint8]uint32
 	initialSpread    int
 	initialTurnNum   int
@@ -119,7 +119,7 @@ func (s *Solver) Init(m1 movegen.MoveGenerator, m2 movegen.MoveGenerator, game *
 	s.stmMovegen = m1
 	s.otsMovegen = m2
 	s.game = game
-	s.killerCache = make(map[uint64]string)
+	s.killerCache = make(map[uint64]*move.Move)
 	s.nodeCount = make(map[uint8]uint32)
 	s.iterativeDeepeningOn = true
 
@@ -525,21 +525,21 @@ func (s *Solver) alphabeta(ctx context.Context, parent *GameNode, parentKey uint
 	if maximizingPlayer {
 		value := float32(-Infinity)
 		plays := s.generateSTMPlays(parent.move, depth, plies)
-		if killerPlay != "" {
+		if killerPlay != nil {
 			// look in the cached node for the winning play last time,
 			// and search it first
 			found := false
 			for idx, play := range plays {
-				if play.ShortDescription() == killerPlay {
+				if play.Equals(killerPlay) {
 					plays[0], plays[idx] = plays[idx], plays[0]
 					found = true
 					break
 				}
 			}
 			if !found {
-				// fmt.Println("killerPlay", killerPlay,
-				// 	"plays", plays,
-				// 	"Zobrist collision - maximizing")
+				fmt.Println("killerPlay", killerPlay,
+					"plays", plays,
+					"Zobrist collision - maximizing")
 			}
 		}
 
@@ -578,27 +578,27 @@ func (s *Solver) alphabeta(ctx context.Context, parent *GameNode, parentKey uint
 		parent.heuristicValue = nodeValue{
 			value:    value,
 			knownEnd: winningNode.heuristicValue.knownEnd}
-		s.killerCache[parentKey] = winningPlay.ShortDescription()
+		s.killerCache[parentKey] = winningPlay
 		return winningNode, nil
 	} else {
 		// Otherwise, not maximizing
 		value := float32(Infinity)
 		plays := s.generateSTMPlays(parent.move, depth, plies)
-		if killerPlay != "" {
+		if killerPlay != nil {
 			// look in the cached node for the winning play last time,
 			// and search it first
 			found := false
 			for idx, play := range plays {
-				if play.ShortDescription() == killerPlay {
+				if play.Equals(killerPlay) {
 					plays[0], plays[idx] = plays[idx], plays[0]
 					found = true
 					break
 				}
 			}
 			if !found {
-				// fmt.Println("killerPlay", killerPlay,
-				// 	"plays", plays,
-				// 	"Zobrist collision - minimizing")
+				fmt.Println("killerPlay", killerPlay,
+					"plays", plays,
+					"Zobrist collision - minimizing")
 			}
 		}
 
@@ -633,7 +633,7 @@ func (s *Solver) alphabeta(ctx context.Context, parent *GameNode, parentKey uint
 		parent.heuristicValue = nodeValue{
 			value:    value,
 			knownEnd: winningNode.heuristicValue.knownEnd}
-		s.killerCache[parentKey] = winningPlay.ShortDescription()
+		s.killerCache[parentKey] = winningPlay
 		return winningNode, nil
 	}
 }

--- a/endgame/alphabeta/alphabeta.go
+++ b/endgame/alphabeta/alphabeta.go
@@ -422,8 +422,8 @@ func (s *Solver) Solve(plies int) (float32, []*move.Move, error) {
 	var bestSeq []*move.Move
 
 	initialHashKey := s.zobrist.Hash(s.game.Board().GetSquares(),
-		s.game.RackFor(s.maximizingPlayer), false)
-
+		s.game.RackFor(s.maximizingPlayer), s.game.RackFor(1-s.maximizingPlayer), false)
+	log.Info().Uint64("initialHashKey", initialHashKey).Msg("starting-zobrist-key")
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -548,7 +548,7 @@ func (s *Solver) alphabeta(ctx context.Context, parent *GameNode, parentKey uint
 		for _, play := range plays {
 			// Play the child
 			s.game.PlayMove(play, false, 0)
-			childKey := s.zobrist.AddMove(parentKey, play, false)
+			childKey := s.zobrist.AddMove(parentKey, play, true)
 			child := new(GameNode)
 			child.move = play
 			child.parent = parent

--- a/endgame/alphabeta/alphabeta_test.go
+++ b/endgame/alphabeta/alphabeta_test.go
@@ -236,7 +236,7 @@ func TestSolveStandard2(t *testing.T) {
 
 func TestVeryDeep(t *testing.T) {
 	is := is.New(t)
-	plies := 5
+	plies := 25
 	// The following is a very deep endgame that requires 25 plies to solve.
 	deepEndgame := "14C/13QI/12FIE/10VEE1R/9KIT2G/8CIG1IDE/8UTA2AS/7ST1SYPh1/6JA5A1/5WOLD2BOBA/3PLOT1R1NU1EX/Y1VEIN1NOR1mOA1/UT1AT1N1L2FEH1/GUR2WIRER5/SNEEZED8 ADENOOO/AHIILMM 353/236 0 lex CSW19;"
 	g, err := cgp.ParseCGP(&DefaultConfig, deepEndgame)

--- a/endgame/alphabeta/alphabeta_test.go
+++ b/endgame/alphabeta/alphabeta_test.go
@@ -236,7 +236,7 @@ func TestSolveStandard2(t *testing.T) {
 
 func TestVeryDeep(t *testing.T) {
 	is := is.New(t)
-	plies := 25
+	plies := 5
 	// The following is a very deep endgame that requires 25 plies to solve.
 	deepEndgame := "14C/13QI/12FIE/10VEE1R/9KIT2G/8CIG1IDE/8UTA2AS/7ST1SYPh1/6JA5A1/5WOLD2BOBA/3PLOT1R1NU1EX/Y1VEIN1NOR1mOA1/UT1AT1N1L2FEH1/GUR2WIRER5/SNEEZED8 ADENOOO/AHIILMM 353/236 0 lex CSW19;"
 	g, err := cgp.ParseCGP(&DefaultConfig, deepEndgame)

--- a/game/display.go
+++ b/game/display.go
@@ -99,7 +99,7 @@ func (g *Game) ToDisplayText() string {
 		log.Debug().Msgf("Event %d: %v", i, evt)
 	}
 
-	if g.turnnum-1 >= 0 {
+	if g.turnnum-1 >= 0 && len(g.history.Events) > g.turnnum-1 {
 		addText(bts, vpadding, hpadding,
 			summary(g.history.Players, g.history.Events[g.turnnum-1]))
 	}

--- a/zobrist/hash_test.go
+++ b/zobrist/hash_test.go
@@ -1,6 +1,7 @@
 package zobrist
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -15,10 +16,11 @@ import (
 var DefaultConfig = config.DefaultConfig()
 
 func TestMain(m *testing.M) {
-	testcommon.CreateGaddags(DefaultConfig, []string{"NWL18"})
+	testcommon.CreateGaddags(DefaultConfig, []string{"NWL18", "CSW19"})
 	os.Exit(m.Run())
 }
 
+/*
 func TestPlayAndUnplay(t *testing.T) {
 	is := is.New(t)
 	z := &Zobrist{}
@@ -66,4 +68,74 @@ func TestPlayAndUnplayMoreLevels(t *testing.T) {
 	is.Equal(h5, h1)
 	h6 := z.AddMove(h5, m1, true)
 	is.Equal(h6, h)
+}
+*/
+
+func TestHashAfterMakingPlay(t *testing.T) {
+	is := is.New(t)
+	z := &Zobrist{}
+	z.Initialize(15)
+
+	endgameCGP := "14C/13QI/12FIE/10VEE1R/9KIT2G/8CIG1IDE/8UTA2AS/7ST1SYPh1/6JA5A1/5WOLD2BOBA/3PLOT1R1NU1EX/Y1VEIN1NOR1mOA1/UT1AT1N1L2FEH1/GUR2WIRER5/SNEEZED8 ADENOOO/AHIILMM 353/236 0 lex CSW19;"
+
+	g, err := cgp.ParseCGP(&DefaultConfig, endgameCGP)
+	is.NoErr(err)
+	alph := alphabet.EnglishAlphabet()
+	h := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("ADENOOO", alph), alphabet.RackFromString("AHIILMM", alph), false)
+
+	m1 := move.NewScoringMoveSimple(8, "15J", "END", "AOOO", alph)
+	h1 := z.AddMove(h, m1, true)
+
+	// Actually play the move on the board.
+	err = g.PlayMove(m1, false, 0)
+	is.NoErr(err)
+
+	h2 := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("AOOO", alph), alphabet.RackFromString("AHIILMM", alph), true)
+	is.Equal(h1, h2)
+}
+
+func TestHashAfterPassing(t *testing.T) {
+	is := is.New(t)
+	z := &Zobrist{}
+	z.Initialize(15)
+
+	endgameCGP := "14C/13QI/12FIE/10VEE1R/9KIT2G/8CIG1IDE/8UTA2AS/7ST1SYPh1/6JA5A1/5WOLD2BOBA/3PLOT1R1NU1EX/Y1VEIN1NOR1mOA1/UT1AT1N1L2FEH1/GUR2WIRER5/SNEEZED8 ADENOOO/AHIILMM 353/236 0 lex CSW19;"
+
+	g, err := cgp.ParseCGP(&DefaultConfig, endgameCGP)
+	is.NoErr(err)
+	alph := alphabet.EnglishAlphabet()
+	h := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("ADENOOO", alph), alphabet.RackFromString("AHIILMM", alph), false)
+
+	m1 := move.NewPassMove(alphabet.RackFromString("ADENOOO", alph).TilesOn(), alph)
+	h1 := z.AddMove(h, m1, true)
+	err = g.PlayMove(m1, false, 0)
+	is.NoErr(err)
+
+	h2 := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("ADENOOO", alph), alphabet.RackFromString("AHIILMM", alph), true)
+	is.Equal(h1, h2)
+}
+
+func TestHashAfterMakingAnotherPlay(t *testing.T) {
+	is := is.New(t)
+	z := &Zobrist{}
+	z.Initialize(15)
+
+	endgameCGP := "14C/13QI/12FIE/10VEE1R/9KIT2G/8CIG1IDE/8UTA2AS/7ST1SYPh1/6JA5AM/5WOLD2BOBA/3PLOT1R1NU1EX/Y1VEIN1NOR1mOAI/UT1AT1N1L2FEHM/GUR2WIRER4A/SNEEZED2END2L AOOO/HI 353/236 0 lex CSW19;"
+
+	g, err := cgp.ParseCGP(&DefaultConfig, endgameCGP)
+	is.NoErr(err)
+	alph := alphabet.EnglishAlphabet()
+	h := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("AOOO", alph), alphabet.RackFromString("HI", alph), false)
+	fmt.Println(g.ToDisplayText())
+	m1 := move.NewScoringMoveSimple(11, "13G", ".O.O", "AO", alph)
+	h1 := z.AddMove(h, m1, true)
+
+	// Actually play the move on the board.
+	err = g.PlayMove(m1, false, 0)
+	is.NoErr(err)
+	fmt.Println("game2")
+	fmt.Println(g.ToDisplayText())
+
+	h2 := z.Hash(g.Board().GetSquares(), alphabet.RackFromString("AO", alph), alphabet.RackFromString("HI", alph), true)
+	is.Equal(h1, h2)
 }


### PR DESCRIPTION
- many more Zobrist collisions than would be expected by chance alone, let alone the fact that they're repeatable. See the "TestVeryDeep" test
- store the entire `*move.Move` instead of a string. Doing `move.ShortDescription()` allocates a lot, although it is bigger. We can maybe go back to a "minimalMove".