### PR TITLE
use proper statistical test for stopping condition

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/domino14/word-golib v0.1.10 h1:+l+50/cq4CzjzpqK3Uiu/cuxn1FL6aXZLSZ12XY9SZ4=
-github.com/domino14/word-golib v0.1.10/go.mod h1:3OMAtX5K/YA/9PQe02h2S7hPfDn6/ZKmrv8vMI2vQss=
 github.com/domino14/word-golib v0.2.0 h1:qLNc0I6+DmoyyuMH35QovitjvSmUunJHtFKg9tGMjLo=
 github.com/domino14/word-golib v0.2.0/go.mod h1:3OMAtX5K/YA/9PQe02h2S7hPfDn6/ZKmrv8vMI2vQss=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/montecarlo/stopping_condition_test.go
+++ b/montecarlo/stopping_condition_test.go
@@ -7,11 +7,25 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestPassTest(t *testing.T) {
+func TestWelchTest(t *testing.T) {
 	is := is.New(t)
-	is.True(passTest(30, 1, 27.2, 1, stats.Z95))
-	is.True(!passTest(30, 1, 29.0, 1, stats.Z95))
+	is.True(welchTest(30, 1, 27.2, 1, stats.Z95))
+	is.True(!welchTest(30, 1, 29.0, 1, stats.Z95))
 
-	is.True(!passTest(100, 5, 90, 4, stats.Z99))
-	is.True(passTest(30, 1, 25, 1, stats.Z999))
+	is.True(!welchTest(100, 5, 90, 4, stats.Z99))
+	is.True(welchTest(30, 1, 25, 1, stats.Z999))
+}
+
+func TestZTest(t *testing.T) {
+	is := is.New(t)
+	is.True(!zTest(100, 96, 1.62, -stats.Z98, false))
+	// actual significance is about 98.6%
+	is.True(zTest(100, 96, 1.62, -stats.Z99, false))
+
+	// Are we 99% sure that 0.002 < 0.005 with the given stderr? Yes
+	is.True(zTest(0.005, 0.002, 0.001, -stats.Z99, true))
+	// Are we 99% sure that 0.998 > 0.995 with the given stderr? Yes
+	is.True(zTest(0.995, 0.998, 0.001, stats.Z99, false))
+	// We are NOT 99% sure that 0.997 > 0.995 with the given stderr.
+	is.True(!zTest(0.995, 0.997, 0.001, stats.Z99, false))
 }


### PR DESCRIPTION
Don't use Welch's t-test for statistically comparing to a fixed win % in order to determine whether to tiebreak by equity. Use regular Z-test.

See #300 