### PR TITLE
fix gcg panic when rack is too long

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -964,6 +964,9 @@ func (g *Game) PlayTurn(t int) error {
 		// at the beginning to whatever was recorded. Drawing like
 		// normal, though, ensures we don't have to reconcile any
 		// tiles with the bag.
+		if cap(g.players[g.onturn].placeholderRack) < m.TilesPlayed()+len(m.Leave()) {
+			g.players[g.onturn].placeholderRack = make([]tilemapping.MachineLetter, m.TilesPlayed()+len(m.Leave()))
+		}
 		drew := g.bag.DrawAtMost(m.TilesPlayed(), g.players[g.onturn].placeholderRack)
 		copy(g.players[g.onturn].placeholderRack[drew:], []tilemapping.MachineLetter(m.Leave()))
 		g.players[g.onturn].setRackTiles(g.players[g.onturn].placeholderRack[:drew+len(m.Leave())], g.alph)


### PR DESCRIPTION
this is a minimal, suboptimal fix for https://github.com/woogles-io/liwords/issues/1364

repro:
from https://discord.com/channels/741321677828522035/1157118170398724176/1276372974483669002 change one line:
```diff
5c5
< >Joshua_Sokol: ?AENORT K5 ARO.NTEd +78 78
---
> >Joshua_Sokol: ?AENORTZ K5 ARO.NTEd +78 78
```
`panic: runtime error: slice bounds out of range [:8] with capacity 7`

---

this does not fix other issues with gcg, for example, from the original source file above, change a different line instead:
```diff
27c27
< >Joshua_Sokol: DIIW C3 IW. +12 448
---
> >Joshua_Sokol: DIIW -IW +0 448
```
`panic: tried to draw 2 tiles, tile bag has 0`
