### PR TITLE
Fix volunteer mode: configurable Woogles URL, proto-JSON serializatio…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ const (
 	ConfigOpenaiBaseURL                    = "openai-base-url"
 	ConfigDeepseekApiKey                   = "deepseek-api-key"
 	ConfigWooglesApiKey                    = "woogles-api-key"
+	ConfigWooglesURL                       = "woogles-url"
 	ConfigAliases                          = "aliases"
 )
 
@@ -114,6 +115,7 @@ func (c *Config) Load(args []string) error {
 	c.BindEnv(ConfigOpenaiApiKey)
 	c.BindEnv(ConfigDeepseekApiKey)
 	c.BindEnv(ConfigWooglesApiKey)
+	c.BindEnv(ConfigWooglesURL)
 
 	cfgdir, err := os.UserConfigDir()
 	if err != nil {
@@ -167,6 +169,7 @@ func (c *Config) Load(args []string) error {
 	c.SetDefault(ConfigOpenaiApiKey, "")
 	c.SetDefault(ConfigDeepseekApiKey, "")
 	c.SetDefault(ConfigWooglesApiKey, "")
+	c.SetDefault(ConfigWooglesURL, "https://woogles.io")
 
 	return nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -203,6 +203,7 @@ type ShellController struct {
 	// Volunteer mode state
 	volunteerMode   bool
 	volunteerStop   bool // Signal to stop after current job
+	volunteerBusy   bool // True while processing a job
 	volunteerCtx    context.Context
 	volunteerCancel context.CancelFunc
 }

--- a/shell/volunteer.go
+++ b/shell/volunteer.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/domino14/macondo/config"
 	"github.com/domino14/macondo/gameanalysis"
@@ -17,7 +17,6 @@ import (
 const (
 	VolunteerPollInterval      = 30 * time.Second
 	VolunteerHeartbeatInterval = 30 * time.Second
-	WooglesBaseURL             = "https://woogles.io"
 )
 
 // volunteer handles the volunteer command
@@ -62,26 +61,88 @@ func (sc *ShellController) startVolunteer() (*Response, error) {
 	return msg("Volunteer mode started. Polling for jobs every 30 seconds...\nUse 'volunteer stop' to exit gracefully."), nil
 }
 
-// stopVolunteer signals volunteer mode to stop after current job
+// stopVolunteer stops volunteer mode, immediately if idle or after current job if busy
 func (sc *ShellController) stopVolunteer() (*Response, error) {
 	if !sc.volunteerMode {
 		return msg("Not in volunteer mode."), nil
 	}
 
-	sc.volunteerStop = true
-	return msg("Volunteer mode will stop after current job completes."), nil
+	if sc.volunteerBusy {
+		sc.volunteerStop = true
+		return msg("Volunteer mode will stop after current job completes."), nil
+	}
+
+	sc.volunteerCancel()
+	return msg("Volunteer mode stopped."), nil
 }
 
 // volunteerLoop polls for jobs and processes them
 func (sc *ShellController) volunteerLoop() {
 	// Get API key and create client
 	apiKey := sc.config.GetString(config.ConfigWooglesApiKey)
-	client := worker.NewWooglesClient(WooglesBaseURL, apiKey)
+	wooglesURL := sc.config.GetString(config.ConfigWooglesURL)
+	client := worker.NewWooglesClient(wooglesURL, apiKey, sc.config)
 
 	ticker := time.NewTicker(VolunteerPollInterval)
 	defer ticker.Stop()
 
 	log.Info().Msg("volunteer loop started")
+
+	poll := func() bool {
+		// Check if we should stop
+		if sc.volunteerStop {
+			log.Info().Msg("volunteer stop requested")
+			sc.cleanupVolunteerMode()
+			return false
+		}
+
+		// Try to claim a job
+		job, err := client.ClaimJob(sc.volunteerCtx)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to claim job")
+			writeln(fmt.Sprintf("Warning: Failed to claim job: %v", err), sc.l.Stdout())
+			return true
+		}
+
+		if job == nil {
+			log.Info().Msg("no jobs available, polling again in 30s")
+			writeln("No jobs available, polling again in 30s...", sc.l.Stdout())
+			return true
+		}
+
+		log.Info().
+			Str("job-id", job.JobID).
+			Str("game-id", job.GameID).
+			Msg("claimed job")
+		writeln(fmt.Sprintf("Claimed job %s for game %s", job.JobID, job.GameID), sc.l.Stdout())
+
+		sc.volunteerBusy = true
+		if err := sc.processVolunteerJob(client, job); err != nil {
+			log.Error().
+				Err(err).
+				Str("job-id", job.JobID).
+				Msg("failed to process job")
+			writeln(fmt.Sprintf("Error processing job: %v", err), sc.l.Stdout())
+		} else {
+			log.Info().
+				Str("job-id", job.JobID).
+				Msg("job completed successfully")
+			writeln(fmt.Sprintf("Job %s completed successfully", job.JobID), sc.l.Stdout())
+		}
+		sc.volunteerBusy = false
+
+		if sc.volunteerStop {
+			log.Info().Msg("volunteer stop requested after job completion")
+			sc.cleanupVolunteerMode()
+			return false
+		}
+		return true
+	}
+
+	// Poll immediately on start
+	if !poll() {
+		return
+	}
 
 	for {
 		select {
@@ -91,52 +152,7 @@ func (sc *ShellController) volunteerLoop() {
 			return
 
 		case <-ticker.C:
-			// Check if we should stop
-			if sc.volunteerStop {
-				log.Info().Msg("volunteer stop requested")
-				sc.cleanupVolunteerMode()
-				return
-			}
-
-			// Try to claim a job
-			job, err := client.ClaimJob(sc.volunteerCtx)
-			if err != nil {
-				log.Warn().Err(err).Msg("failed to claim job")
-				writeln(fmt.Sprintf("Warning: Failed to claim job: %v", err), sc.l.Stdout())
-				continue
-			}
-
-			if job == nil {
-				// No jobs available
-				log.Debug().Msg("no jobs available")
-				continue
-			}
-
-			// Got a job! Process it
-			log.Info().
-				Str("job-id", job.JobID).
-				Str("game-id", job.GameID).
-				Msg("claimed job")
-			writeln(fmt.Sprintf("Claimed job %s for game %s", job.JobID, job.GameID), sc.l.Stdout())
-
-			// Process the job
-			if err := sc.processVolunteerJob(client, job); err != nil {
-				log.Error().
-					Err(err).
-					Str("job-id", job.JobID).
-					Msg("failed to process job")
-				writeln(fmt.Sprintf("Error processing job: %v", err), sc.l.Stdout())
-			} else {
-				log.Info().
-					Str("job-id", job.JobID).
-					Msg("job completed successfully")
-				writeln(fmt.Sprintf("Job %s completed successfully", job.JobID), sc.l.Stdout())
-			}
-
-			// After processing, check if we should stop
-			if sc.volunteerStop {
-				log.Info().Msg("volunteer stop requested after job completion")
-				sc.cleanupVolunteerMode()
+			if !poll() {
 				return
 			}
 		}
@@ -256,11 +272,10 @@ func (sc *ShellController) processVolunteerJob(client *worker.WooglesClient, job
 		Int("turns-analyzed", len(result.Turns)).
 		Msg("analysis complete")
 
-	// Convert result to protobuf
+	// Convert result to protobuf and serialize as proto-JSON
 	resultProto := result.ToProto()
 
-	// Serialize to bytes
-	resultBytes, err := proto.Marshal(resultProto)
+	resultBytes, err := protojson.Marshal(resultProto)
 	if err != nil {
 		return fmt.Errorf("failed to marshal result: %w", err)
 	}

--- a/worker/client.go
+++ b/worker/client.go
@@ -19,14 +19,16 @@ type WooglesClient struct {
 	baseURL    string
 	apiKey     string
 	httpClient *http.Client
+	cfg        *config.Config
 }
 
 // NewWooglesClient creates a new Woogles API client
-func NewWooglesClient(baseURL, apiKey string) *WooglesClient {
+func NewWooglesClient(baseURL, apiKey string, cfg *config.Config) *WooglesClient {
 	return &WooglesClient{
 		baseURL:    baseURL,
 		apiKey:     apiKey,
 		httpClient: &http.Client{},
+		cfg:        cfg,
 	}
 }
 
@@ -63,17 +65,17 @@ func (c *WooglesClient) ClaimJob(ctx context.Context) (*Job, error) {
 
 	// Parse Connect RPC JSON response
 	var claimResp struct {
-		NoJobs bool `json:"noJobs"`
-		JobId  string `json:"jobId"`
-		GameId string `json:"gameId"`
+		NoJobs bool   `json:"no_jobs"`
+		JobId  string `json:"job_id"`
+		GameId string `json:"game_id"`
 		Config struct {
-			SimPlaysEarlyMid        int32 `json:"simPlaysEarlyMid"`
-			SimPliesEarlyMid        int32 `json:"simPliesEarlyMid"`
-			SimStopEarlyMid         int32 `json:"simStopEarlyMid"`
-			SimPlaysEarlyPreendgame int32 `json:"simPlaysEarlyPreendgame"`
-			SimPliesEarlyPreendgame int32 `json:"simPliesEarlyPreendgame"`
-			SimStopEarlyPreendgame  int32 `json:"simStopEarlyPreendgame"`
-			PegEarlyCutoff          bool  `json:"pegEarlyCutoff"`
+			SimPlaysEarlyMid        int32 `json:"sim_plays_early_mid"`
+			SimPliesEarlyMid        int32 `json:"sim_plies_early_mid"`
+			SimStopEarlyMid         int32 `json:"sim_stop_early_mid"`
+			SimPlaysEarlyPreendgame int32 `json:"sim_plays_early_preendgame"`
+			SimPliesEarlyPreendgame int32 `json:"sim_plies_early_preendgame"`
+			SimStopEarlyPreendgame  int32 `json:"sim_stop_early_preendgame"`
+			PegEarlyCutoff          bool  `json:"peg_early_cutoff"`
 			Threads                 int32 `json:"threads"`
 		} `json:"config"`
 	}
@@ -252,10 +254,7 @@ func (c *WooglesClient) FetchGameHistory(ctx context.Context, gameID string) (*p
 		return nil, fmt.Errorf("failed to unmarshal GCG response: %w", err)
 	}
 
-	// Parse GCG into GameHistory (need a config for parsing, but we don't need full config here)
-	// Use a minimal config just for parsing
-	parseConfig := &config.Config{}
-	history, err := gcgio.ParseGCGFromReader(parseConfig, strings.NewReader(gcgObj.GCG))
+	history, err := gcgio.ParseGCGFromReader(c.cfg, strings.NewReader(gcgObj.GCG))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse GCG: %w", err)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/domino14/macondo/gameanalysis"
 )
@@ -20,7 +20,7 @@ type AnalysisWorker struct {
 
 // NewAnalysisWorker creates a new worker
 func NewAnalysisWorker(cfg *WorkerConfig) *AnalysisWorker {
-	client := NewWooglesClient(cfg.WooglesBaseURL, cfg.APIKey)
+	client := NewWooglesClient(cfg.WooglesBaseURL, cfg.APIKey, cfg.MacondoConfig)
 
 	// Create analyzer with default config if none provided
 	analysisConfig := gameanalysis.DefaultAnalysisConfig()
@@ -149,7 +149,7 @@ func (w *AnalysisWorker) processJob(ctx context.Context, job *Job) error {
 	resultProto := result.ToProto()
 
 	// Serialize to bytes
-	resultBytes, err := proto.Marshal(resultProto)
+	resultBytes, err := protojson.Marshal(resultProto)
 	if err != nil {
 		return fmt.Errorf("failed to marshal result: %w", err)
 	}


### PR DESCRIPTION
…n, and stop behavior

- Add `woogles-url` config key (defaults to https://woogles.io) so the URL is no longer hardcoded in volunteer.go
- Pass the full config to WooglesClient so GCG parsing uses real lexicon paths instead of an empty config
- Switch result serialization from binary proto to proto-JSON (protojson) in both the shell volunteer loop and the standalone worker
- Fix JSON field names in ClaimJob response struct to use snake_case to match the actual API response
- Add `volunteerBusy` flag so `volunteer stop` halts immediately when idle instead of always waiting for the next poll tick
- Poll immediately on volunteer loop start rather than waiting 30 s