### PR TITLE
Fix PEG state stack overflow in deep recursive paths

### DIFF
--- a/preendgame/peg.go
+++ b/preendgame/peg.go
@@ -531,10 +531,21 @@ func (s *Solver) Solve(ctx context.Context) ([]*PreEndgamePlay, error) {
 			// Copy the game so each endgame solver can manipulate it independently.
 			g := s.game.Copy()
 			g.SetBackupMode(game.SimulationMode)
-			// we need to set the state stack length now to account for the PEG move.
-			// there can also be passes etc. just add a hacky number.
-			// XXX: state stack length should probably just be a fixed large number.
-			g.SetStateStackLength(s.curEndgamePlies + 5)
+			// Size the state stack to cover the deepest path we can hit.
+			//
+			// recursiveSolve plays moves (both ours and opponent responses)
+			// until the bag empties or the game ends, then QuickAndDirtySolve
+			// recurses `curEndgamePlies` more levels via negamax. Each
+			// PlayMove/PlaySmallMove call pushes one state onto the stack.
+			//
+			// In the worst case, every tile play drains only one tile from
+			// the bag and each is interleaved with a forced-pass response
+			// (e.g. opponent has an unplayable rack). With two consecutive
+			// passes ending the game, the pattern "pass, tile, pass, tile,
+			// ..., pass, tile" reaches 2*numinbag PlayMove calls before the
+			// bag is empty. Negamax then adds up to curEndgamePlies more
+			// pushes. Add a small cushion for safety.
+			g.SetStateStackLength(2*s.numinbag + s.curEndgamePlies + 5)
 			g.SetEndgameMode(true)
 			// Set a fixed order for the bag. This makes it easy for us to control
 			// what tiles we draw after making a move.


### PR DESCRIPTION
The pre-endgame solver sized its endgame game's state stack to `curEndgamePlies + 5`, which is too small for recursive paths that drain the bag slowly.

In the worst case, `recursiveSolve` can make 2*numinbag PlayMove calls before the bag is empty (the "pass, tile, pass, tile, ..." pattern when opponent responses are forced passes). `QuickAndDirtySolve` then pushes up to `curEndgamePlies` more states via negamax. For even modest configurations (4 tiles in the bag, 2 endgame plies) the previous formula produced a stack of 7 slots while up to 10 were needed, triggering `runtime error: index out of range [7] with length 7` from `Game.backupState`.

Resize the stack to `2*numinbag + curEndgamePlies + 5` so the deepest possible path always fits, with some slack.

Reported via `peg -opprack OOT?` on a 4-tile-in-bag position.