### PR TITLE
Add debug tracing for PEG solver endgame analysis

### DIFF
--- a/preendgame/peg.go
+++ b/preendgame/peg.go
@@ -432,6 +432,14 @@ type Solver struct {
 
 	// Per-thread arenas for SmallMove slices used in recursiveSolve.
 	arenas []*tinymove.SmallMoveArena
+
+	// Debug trace fields — zero-valued means tracing disabled.
+	traceWriter          io.Writer
+	traceTargetFirstRack string // sorted letters to match for opp rack, e.g. "AEELNRS"
+	traceTargetBagTail   string // ordered bag remainder to match, e.g. "GEI"
+	traceOnce            bool
+	traceSeenMatch       atomic.Bool
+	traceMu              sync.Mutex
 }
 
 // Init initializes the solver. It creates all the parallel endgame solvers.
@@ -459,6 +467,21 @@ func (s *Solver) Init(g *game.Game, gd *kwg.KWG) error {
 
 func (s *Solver) SetLogStream(l io.Writer) {
 	s.logStream = l
+}
+
+func (s *Solver) SetTraceWriter(w io.Writer)        { s.traceWriter = w }
+func (s *Solver) SetTraceTargetFirstRack(r string)  { s.traceTargetFirstRack = r }
+func (s *Solver) SetTraceTargetBagTail(tail string) { s.traceTargetBagTail = tail }
+func (s *Solver) SetTraceOnce(once bool)            { s.traceOnce = once }
+
+func (s *Solver) trace(indent int, format string, args ...any) {
+	if s.traceWriter == nil {
+		return
+	}
+	s.traceMu.Lock()
+	defer s.traceMu.Unlock()
+	fmt.Fprint(s.traceWriter, strings.Repeat("  ", indent))
+	fmt.Fprintf(s.traceWriter, format+"\n", args...)
 }
 
 func (s *Solver) Solve(ctx context.Context) ([]*PreEndgamePlay, error) {
@@ -618,7 +641,7 @@ func (s *Solver) Solve(ctx context.Context) ([]*PreEndgamePlay, error) {
 			// PEG only needs the spread value from QDS, not the move sequence.
 			// Skipping MaterializeFull avoids a full Game.Copy per QDS call
 			// (which was 93% of all allocations in profiles).
-			es.SetSkipMaterialize(true)
+			es.SetSkipMaterialize(s.traceWriter == nil)
 			// Even though the endgame search window is already tiny, this still seems to help
 			// for some reason:
 			es.SetNegascoutOptim(true)

--- a/preendgame/peg_debug_test.go
+++ b/preendgame/peg_debug_test.go
@@ -1,0 +1,66 @@
+package preendgame
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/domino14/word-golib/kwg"
+	"github.com/domino14/word-golib/tilemapping"
+	"github.com/matryer/is"
+
+	"github.com/domino14/macondo/cgp"
+	"github.com/domino14/macondo/move"
+)
+
+// TestDebugPegHiedGEI traces one specific bag outcome (opp=LEANERS, bag=GEI)
+// through the full PEG recursion for play 13M P(AH). Remove the t.Skip to run.
+// Output goes to preendgame/peg-debug-hied-GEI.txt.
+func TestDebugPegHiedGEI(t *testing.T) {
+	t.Skip("manual debug harness; comment out to run")
+
+	const cgpStr = "BEDEL10/R1R9U2/9FLENCHES/15/15/15/15/15/15/15/15/INRO11/15/15/15 ?ANNOPY/AEEGLRS 344/368 0 lex CSW21;"
+
+	is := is.New(t)
+	g, err := cgp.ParseCGP(DefaultConfig, cgpStr)
+	is.NoErr(err)
+	g.RecalculateBoard()
+
+	gd, err := kwg.GetKWG(DefaultConfig.WGLConfig(), "CSW21")
+	is.NoErr(err)
+
+	peg := &Solver{}
+	is.NoErr(peg.Init(g.Game, gd))
+
+	// 13M P(AH) scores 32; leave after playing P from ?ANNOPY is ?ANNOY.
+	m := move.NewScoringMoveSimple(32, "13M", "P..", "?ANNOY", g.Alphabet())
+	peg.SetSolveOnly([]*move.Move{m})
+	peg.SetThreads(1)
+	peg.SetEndgamePlies(4)
+	peg.SetIterativeDeepening(false)
+	peg.SetNestedDepthLimit(3)
+	peg.SetSkipDeepPass(false)
+	peg.SetSkipTiebreaker(true)
+
+	// Trace only the perm where opp draws LEANERS and bag tail is GEI (in order).
+	peg.SetTraceTargetFirstRack("AEELNRS") // LEANERS sorted
+	peg.SetTraceTargetBagTail("GEI")
+	peg.SetTraceOnce(true)
+
+	f, err := os.Create("peg-debug-hied-GEI.txt")
+	is.NoErr(err)
+	defer f.Close()
+	peg.SetTraceWriter(f)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
+	defer cancel()
+
+	winners, err := peg.Solve(ctx)
+	is.True(err == nil || err == ErrCanceledEarly)
+
+	for _, o := range winners[0].OutcomesArray() {
+		tiles := tilemapping.MachineWord(o.Tiles()).UserVisible(g.Alphabet())
+		t.Logf("bag=%s outcome=%s count=%d", tiles, o.OutcomeResult(), o.Count())
+	}
+}

--- a/preendgame/peg_generic.go
+++ b/preendgame/peg_generic.go
@@ -430,6 +430,53 @@ type option struct {
 	idx         int
 }
 
+// permMatchesTrace returns true when this permutation should be processed.
+// Always true when tracing is off. When tracing is on, matches
+// sorted(mls[:7]) against traceTargetFirstRack and mls[7:] against
+// traceTargetBagTail. When traceOnce is set, only the first matching perm
+// is accepted.
+func (s *Solver) permMatchesTrace(g *game.Game, mls []tilemapping.MachineLetter) bool {
+	if s.traceWriter == nil {
+		return true
+	}
+	if s.traceTargetFirstRack == "" && s.traceTargetBagTail == "" {
+		return true
+	}
+	if s.traceOnce && s.traceSeenMatch.Load() {
+		return false
+	}
+	alpha := g.Alphabet()
+	rackSize := min(game.RackTileLimit, len(mls))
+	if s.traceTargetFirstRack != "" {
+		rackStr := tilemapping.MachineWord(mls[:rackSize]).UserVisible(alpha)
+		rackBytes := []byte(rackStr)
+		sort.Slice(rackBytes, func(i, j int) bool { return rackBytes[i] < rackBytes[j] })
+		if string(rackBytes) != s.traceTargetFirstRack {
+			return false
+		}
+	}
+	if s.traceTargetBagTail != "" && len(mls) > rackSize {
+		tail := tilemapping.MachineWord(mls[rackSize:]).UserVisible(alpha)
+		if tail != s.traceTargetBagTail {
+			return false
+		}
+	}
+	s.traceSeenMatch.Store(true)
+	return true
+}
+
+// smallMoveStr formats a SmallMove into a human-readable coordinate string.
+func smallMoveStr(sm tinymove.SmallMove) string {
+	if sm.IsPass() {
+		return "PASS"
+	}
+	row, col, vert := sm.CoordsAndVertical()
+	if vert {
+		return fmt.Sprintf("%c%d score=%d", 'A'+col, row+1, sm.Score())
+	}
+	return fmt.Sprintf("%d%c score=%d", row+1, 'A'+col, sm.Score())
+}
+
 func (s *Solver) handleJobGeneric(ctx context.Context, j job, thread int,
 	winnerChan chan *PreEndgamePlay) error {
 	s.arenas[thread].Reset()
@@ -514,6 +561,16 @@ func (s *Solver) processJobPerPerm(ctx context.Context, j job, thread int,
 	if err != nil {
 		return err
 	}
+
+	if !s.permMatchesTrace(g, j.opt.mls) {
+		return nil
+	}
+	s.trace(0, "[outer] play=%s opp-rack=%s our-rack=%s bag-tail=%s perm-count=%d",
+		j.ourMove.Play.ShortDescription(),
+		g.RackLettersFor(1-g.PlayerOnTurn()),
+		g.RackLettersFor(g.PlayerOnTurn()),
+		s.traceTargetBagTail,
+		j.opt.ct)
 
 	var sm tinymove.SmallMove
 	if j.ourMove.Play.Action() == move.MoveTypePass {
@@ -625,6 +682,16 @@ func (s *Solver) processJobPerPlay(ctx context.Context, j job, thread int,
 			return err
 		}
 
+		if !s.permMatchesTrace(g, options[idx].mls) {
+			continue
+		}
+		s.trace(0, "[outer] play=%s opp-rack=%s our-rack=%s bag-tail=%s perm-count=%d",
+			j.ourMove.Play.ShortDescription(),
+			g.RackLettersFor(1-g.PlayerOnTurn()),
+			g.RackLettersFor(g.PlayerOnTurn()),
+			s.traceTargetBagTail,
+			options[idx].ct)
+
 		var sm tinymove.SmallMove
 		if j.ourMove.Play.Action() == move.MoveTypePass {
 			sm = tinymove.PassMove()
@@ -714,6 +781,10 @@ func (s *Solver) recursiveSolve(ctx context.Context, thread int, pegPlay *PreEnd
 			}
 		}
 
+		s.trace(depth+nestedDepth*4, "[d=%d n=%d] endgame spread=%+d pv=[%s] oppPerspective=%v",
+			depth, nestedDepth, finalSpread,
+			s.endgameSolvers[thread].ShortDetails(), oppPerspective)
+
 		switch {
 		case (finalSpread > 0 && oppPerspective) || (finalSpread < 0 && !oppPerspective):
 			// win for our opponent = loss for us
@@ -779,6 +850,13 @@ func (s *Solver) recursiveSolve(ctx context.Context, thread int, pegPlay *PreEnd
 		log.Err(err).Msg("play-move-err")
 		return err
 	}
+	s.trace(depth+nestedDepth*4, "[d=%d n=%d] played=%s our=%s opp=%s bag-remaining=%d scoreless=%d",
+		depth, nestedDepth,
+		smallMoveStr(moveToMake),
+		g.RackLettersFor(s.solvingForPlayer),
+		g.RackLettersFor(1-s.solvingForPlayer),
+		g.Bag().TilesRemaining(),
+		g.ScorelessTurns())
 
 	// If the bag is STILL not empty after making our last move:
 	if g.Bag().TilesRemaining() > 0 && g.Playing() != macondo.PlayState_GAME_OVER {
@@ -838,6 +916,8 @@ func (s *Solver) iterateOppReplies(ctx context.Context, thread int, pegPlay *Pre
 	inbagOption option, winnerChan chan *PreEndgamePlay, depth int,
 	pegPlayEmptiesBag, fullSolve bool, genPlays []tinymove.SmallMove, nestedDepth int) error {
 	for idx := range genPlays {
+		s.trace(depth+nestedDepth*4, "[d=%d n=%d] opp-reply %d/%d %s",
+			depth, nestedDepth, idx+1, len(genPlays), smallMoveStr(genPlays[idx]))
 		err := s.recursiveSolve(ctx, thread, pegPlay, genPlays[idx], inbagOption, winnerChan, depth+1, pegPlayEmptiesBag, fullSolve, nestedDepth)
 		if err != nil {
 			log.Err(err).Msg("recursive-solve-err")
@@ -941,9 +1021,18 @@ func (s *Solver) nestedOurTurnSolve(ctx context.Context, thread int, nestedDepth
 	copy(subPlays, ourPlays)
 	defer s.arenas[thread].Dealloc(len(subPlays))
 
+	s.trace(nestedDepth*4, "[nested=%d] ENTER our=%s opp=%s bag=%s subBagSize=%d numSubPerms=%d numSubPlays=%d",
+		nestedDepth,
+		g.RackLettersFor(g.PlayerOnTurn()),
+		g.RackLettersFor(opp),
+		tilemapping.MachineWord(g.Bag().Peek()).UserVisible(g.Alphabet()),
+		subBagSize, len(subPerms), len(subPlays))
+
 	anyNonLoss := false
 
-	for _, subM := range subPlays {
+	for subMIdx, subM := range subPlays {
+		s.trace(nestedDepth*4, "[nested=%d] subM %d/%d %s",
+			nestedDepth, subMIdx+1, len(subPlays), smallMoveStr(subM))
 		subPegPlay := &PreEndgamePlay{Play: &move.Move{}}
 		subEmptiesBag := int(subM.TilesPlayed()) >= subBagSize
 
@@ -956,6 +1045,10 @@ func (s *Solver) nestedOurTurnSolve(ctx context.Context, thread int, nestedDepth
 
 			s.numSubPermsEvaluated.Add(1)
 			s.threadSubPermsEvaluated[thread]++
+
+			s.trace(nestedDepth*4+2, "[nested=%d]   subPerm %d/%d tiles=%s",
+				nestedDepth, pi+1, len(subPerms),
+				tilemapping.MachineWord(tiles).UserVisible(g.Alphabet()))
 
 			// Mirror handleJobGeneric's per-permutation setup (peg_generic.go:482-490):
 			// put opp's tiles back in the bag, reorder for this sub-perm, redraw opp's rack.
@@ -974,6 +1067,7 @@ func (s *Solver) nestedOurTurnSolve(ctx context.Context, thread int, nestedDepth
 			// Early exit: a loss for any sub-perm means this sub-play can never
 			// be guaranteed-win or guaranteed-non-loss. Skip remaining sub-perms.
 			if subPegPlay.HasLoss(subOption.mls) {
+				s.trace(nestedDepth*4+2, "[nested=%d]   LOSS on this subM, skipping remaining perms", nestedDepth)
 				break
 			}
 		}
@@ -981,6 +1075,7 @@ func (s *Solver) nestedOurTurnSolve(ctx context.Context, thread int, nestedDepth
 		subPegPlay.finalize()
 
 		if subPegPlay.IsGuaranteedWin() {
+			s.trace(nestedDepth*4, "[nested=%d] VERDICT=WIN (subM %d guaranteed win)", nestedDepth, subMIdx+1)
 			return PEGWin, nil
 		}
 		if subPegPlay.IsGuaranteedNonLoss() {
@@ -989,8 +1084,10 @@ func (s *Solver) nestedOurTurnSolve(ctx context.Context, thread int, nestedDepth
 	}
 
 	if anyNonLoss {
+		s.trace(nestedDepth*4, "[nested=%d] VERDICT=DRAW (no guaranteed win, but some non-loss)", nestedDepth)
 		return PEGDraw, nil
 	}
+	s.trace(nestedDepth*4, "[nested=%d] VERDICT=LOSS (all subMs lead to loss)", nestedDepth)
 	return PEGLoss, nil
 }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive debug tracing capabilities to the PEG (Pre-Endgame) solver, allowing developers to trace specific bag permutations and opponent rack outcomes through the full recursion tree. This is useful for understanding solver behavior and debugging complex endgame scenarios.

## Key Changes

- **New tracing infrastructure in `peg.go`**:
  - Added `traceWriter`, `traceTargetFirstRack`, `traceTargetBagTail`, `traceOnce`, and `traceSeenMatch` fields to the `Solver` struct
  - Implemented setter methods: `SetTraceWriter()`, `SetTraceTargetFirstRack()`, `SetTraceTargetBagTail()`, `SetTraceOnce()`
  - Added `trace()` method for thread-safe formatted output with indentation support

- **Filtering logic in `peg_generic.go`**:
  - Implemented `permMatchesTrace()` to filter permutations based on opponent rack and bag tail
  - Supports matching sorted opponent rack letters (e.g., "AEELNRS") and ordered bag remainder (e.g., "GEI")
  - Respects `traceOnce` flag to only accept the first matching permutation

- **Trace points added throughout recursion**:
  - `processJobPerPerm()` and `processJobPerPlay()`: Log outer play details and permutation counts
  - `recursiveSolve()`: Log endgame spread results and move execution details
  - `iterateOppReplies()`: Log opponent reply iteration
  - `nestedOurTurnSolve()`: Log nested solve entry/exit, sub-move evaluation, and verdicts (WIN/DRAW/LOSS)

- **Helper function**:
  - Added `smallMoveStr()` to format moves as human-readable coordinates (e.g., "13M score=32" or "PASS")

- **Test harness in `peg_debug_test.go`**:
  - Added `TestDebugPegHiedGEI()` as a manual debug harness demonstrating trace usage
  - Shows how to target specific bag outcomes and trace through full PEG recursion

- **Optimization**:
  - Modified endgame solver initialization to skip materialization when tracing is disabled, preserving performance in normal operation

## Implementation Details

The tracing system uses indentation levels to show recursion depth, making it easy to follow the solver's decision tree. The `permMatchesTrace()` function filters at the permutation level, ensuring only relevant bag outcomes are traced. Thread safety is maintained via `sync.Mutex` for trace output and `atomic.Bool` for the match flag.

https://claude.ai/code/session_012U2VdiUngS6DRFqpmBtX6q