### PR TITLE
Prevent volunteer crash on corrupt games; report failure to server

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -583,6 +583,10 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, updateCross
 		if m.TilesPlayed() == RackTileLimit {
 			g.players[g.onturn].bingos++
 		}
+		if m.TilesPlayed()+len(m.Leave()) > cap(g.players[g.onturn].placeholderRack) {
+			return fmt.Errorf("malformed move: tiles played (%d) + leave (%d) exceeds rack capacity (%d)",
+				m.TilesPlayed(), len(m.Leave()), cap(g.players[g.onturn].placeholderRack))
+		}
 		drew := g.bag.DrawAtMost(m.TilesPlayed(), g.players[g.onturn].placeholderRack)
 		copy(g.players[g.onturn].placeholderRack[drew:], []tilemapping.MachineLetter(m.Leave()))
 		g.players[g.onturn].setRackTiles(g.players[g.onturn].placeholderRack[:drew+len(m.Leave())], g.alph)
@@ -645,6 +649,10 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, updateCross
 		}
 
 	case move.MoveTypeExchange:
+		if len(m.Tiles())+len(m.Leave()) > cap(g.players[g.onturn].placeholderRack) {
+			return fmt.Errorf("malformed exchange: tiles (%d) + leave (%d) exceeds rack capacity (%d)",
+				len(m.Tiles()), len(m.Leave()), cap(g.players[g.onturn].placeholderRack))
+		}
 		err := g.bag.Exchange([]tilemapping.MachineLetter(m.Tiles()), g.players[g.onturn].placeholderRack)
 		if err != nil {
 			return err

--- a/shell/volunteer.go
+++ b/shell/volunteer.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -160,7 +161,24 @@ func (sc *ShellController) volunteerLoop() {
 }
 
 // processVolunteerJob analyzes a game and submits the result
-func (sc *ShellController) processVolunteerJob(client *worker.WooglesClient, job *worker.Job) error {
+func (sc *ShellController) processVolunteerJob(client *worker.WooglesClient, job *worker.Job) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Str("job-id", job.JobID).
+				Str("game-id", job.GameID).
+				Msg("recovered from panic in volunteer job; marking job failed")
+			msg := fmt.Sprintf("worker panic on game %s: %v", job.GameID, r)
+			if ferr := client.FailJob(context.Background(), job.JobID, msg); ferr != nil {
+				log.Warn().Err(ferr).Str("job-id", job.JobID).Msg("failed to report job failure to server")
+			}
+			err = fmt.Errorf("panic recovered: %v", r)
+		}
+	}()
+
 	ctx := sc.volunteerCtx
 
 	// Start heartbeat ticker

--- a/worker/client.go
+++ b/worker/client.go
@@ -233,6 +233,42 @@ func (c *WooglesClient) SendHeartbeat(ctx context.Context, jobID string, progres
 	return nil
 }
 
+// FailJob reports a job as permanently failed to the server. Use this when
+// a panic or unrecoverable error occurs processing a specific game so the
+// job is not retried on other volunteers.
+func (c *WooglesClient) FailJob(ctx context.Context, jobID, errorMessage string) error {
+	url := c.baseURL + "/api/analysis_service.AnalysisQueueService/FailJob"
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"jobId":          jobID,
+		"errorMessage":   errorMessage,
+		"macondoVersion": c.version,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
 // FetchGameHistory fetches the game history from Woogles
 func (c *WooglesClient) FetchGameHistory(ctx context.Context, gameID string) (*pb.GameHistory, error) {
 	url := c.baseURL + "/api/game_service.GameMetadataService/GetGCG"


### PR DESCRIPTION
Guard playMove against malformed moves where TilesPlayed+Leave exceeds rack capacity (7), returning a typed error instead of panicking with slice bounds out of range. Same guard added to the exchange path.

Add panic recovery in processVolunteerJob so any unhandled panic keeps the volunteer loop alive. On recovery, call the new FailJob RPC to immediately mark the job failed on the server with a descriptive error message, rather than letting it silently burn through 3 retry attempts on other volunteers before dying with a generic timeout message.

Add WooglesClient.FailJob to worker/client.go to POST to the new /api/analysis_service.AnalysisQueueService/FailJob endpoint.