### PR TITLE
Remove sketchy guards in playMove and exchange paths

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -583,10 +583,6 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, updateCross
 		if m.TilesPlayed() == RackTileLimit {
 			g.players[g.onturn].bingos++
 		}
-		if m.TilesPlayed()+len(m.Leave()) > cap(g.players[g.onturn].placeholderRack) {
-			return fmt.Errorf("malformed move: tiles played (%d) + leave (%d) exceeds rack capacity (%d)",
-				m.TilesPlayed(), len(m.Leave()), cap(g.players[g.onturn].placeholderRack))
-		}
 		drew := g.bag.DrawAtMost(m.TilesPlayed(), g.players[g.onturn].placeholderRack)
 		copy(g.players[g.onturn].placeholderRack[drew:], []tilemapping.MachineLetter(m.Leave()))
 		g.players[g.onturn].setRackTiles(g.players[g.onturn].placeholderRack[:drew+len(m.Leave())], g.alph)
@@ -649,10 +645,6 @@ func (g *Game) playMove(m *move.Move, addToHistory bool, millis int, updateCross
 		}
 
 	case move.MoveTypeExchange:
-		if len(m.Tiles())+len(m.Leave()) > cap(g.players[g.onturn].placeholderRack) {
-			return fmt.Errorf("malformed exchange: tiles (%d) + leave (%d) exceeds rack capacity (%d)",
-				len(m.Tiles()), len(m.Leave()), cap(g.players[g.onturn].placeholderRack))
-		}
 		err := g.bag.Exchange([]tilemapping.MachineLetter(m.Tiles()), g.players[g.onturn].placeholderRack)
 		if err != nil {
 			return err


### PR DESCRIPTION
The TilesPlayed()-based guard was broken: TilesPlayed() counts ALL non-zero tiles in the move's tile array, including play-through tiles encoded as designated blanks (e.g. blank-X = 24|0x80). This caused false positives for legal moves that play through existing blanks on the board. The exchange guard was harmless but redundant.

Corruption is now caught upstream by validateGameHistory before any game replay begins, so these guards in the hot path are unnecessary.