### PR TITLE
Complete leave posterior via marginal-lift imputation

### DIFF
--- a/ai/bot/elite.go
+++ b/ai/bot/elite.go
@@ -243,10 +243,16 @@ func nonEndgameBest(ctx context.Context, p *BotTurnPlayer, simPlies int, moves [
 	// p.simmer.SetAutostopPPScaling(1500)
 
 	if HasInfer(p.botType) && inferenceRan {
-		nInferred := len(p.inferencer.Inferences().InferredRacks)
-		if nInferred > InferencesSimLimit {
+		inferences := p.inferencer.Inferences()
+		nInferred := len(inferences.InferredRacks)
+		if inferences.Complete {
+			// Complete posterior over every feasible leave: sample it
+			// directly, no count threshold or random fallback needed.
+			logger.Info().Int("inferences", nInferred).Msg("using complete inference posterior in sim")
+			p.simmer.SetInferences(inferences.InferredRacks, inferences.RackLength, montecarlo.InferenceCompletePosterior)
+		} else if nInferred > InferencesSimLimit {
 			logger.Info().Int("inferences", nInferred).Msg("using inferences in sim")
-			p.simmer.SetInferences(p.inferencer.Inferences().InferredRacks, p.inferencer.Inferences().RackLength, montecarlo.InferenceWeightedRandomRacks)
+			p.simmer.SetInferences(inferences.InferredRacks, inferences.RackLength, montecarlo.InferenceWeightedRandomRacks)
 		} else {
 			logger.Info().Int("inferences", nInferred).Msg("too few inferences, skipping")
 		}

--- a/cmd/inferdiag/main.go
+++ b/cmd/inferdiag/main.go
@@ -193,6 +193,7 @@ func runTier2(
 	ev *tier2Evaluator,
 	inferredRacks []montecarlo.InferredRack,
 	rackLength int,
+	completePosterior bool,
 	trueLeave []tilemapping.MachineLetter,
 	trueLeaveFound bool,
 	ctx context.Context,
@@ -238,7 +239,11 @@ func runTier2(
 	// 2. Inferred: use posterior racks.
 	if len(inferredRacks) > 0 {
 		result.Inferred, err = runEval(func() {
-			ev.simmer.SetInferences(inferredRacks, rackLength, montecarlo.InferenceWeightedRandomRacks)
+			mode := montecarlo.InferenceWeightedRandomRacks
+			if completePosterior {
+				mode = montecarlo.InferenceCompletePosterior
+			}
+			ev.simmer.SetInferences(inferredRacks, rackLength, mode)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("tier2 inferred: %w", err)
@@ -470,7 +475,7 @@ func runInference(
 
 	// Tier 2: evaluate move quality under three rack assumptions.
 	if ev != nil {
-		t2, err := runTier2(g, ev, allRacks, inferences.RackLength, trueLeave, trueLeaveFound, ctx)
+		t2, err := runTier2(g, ev, allRacks, inferences.RackLength, inferences.Complete, trueLeave, trueLeaveFound, ctx)
 		if err != nil {
 			log.Debug().Err(err).Msg("tier2-skipped")
 		} else {

--- a/docs/development/iterative_inference_plan.md
+++ b/docs/development/iterative_inference_plan.md
@@ -220,6 +220,17 @@ gets an equal share of the remainder divided by the rounds left, so early
 termination hands its time back. Evaluations cost the same ~100 ms mini-sim in
 every round — the total `-time` is unchanged, only its allocation moves.
 
+Two things make the split leakier than it looks, and the loop has to tolerate
+both. Round 0 *overruns* its sub-deadline, because the in-flight mini-sims on
+every thread must finish before the sampling loop can exit; on a slow or
+oversubscribed machine that overrun can consume most of what was reserved for
+refinement. And the rate at which leaves can be evaluated is only known after
+round 0 has run. So a round is never refused for being small: a batch below
+`refineMinBatch` still runs and its measurements still count, it just cannot
+satisfy the stopping rule. Refusing it would leave the reserved time unspent
+and make inference strictly worse than never having split the budget — the
+failure mode that motivated this note.
+
 ## 4. Changes
 
 ### `rangefinder/imputation.go` — weighted accumulator

--- a/docs/development/iterative_inference_plan.md
+++ b/docs/development/iterative_inference_plan.md
@@ -1,0 +1,300 @@
+# Iterative measure–impute–recalibrate inference
+
+Supersedes `two_stage_inference_plan.md`, which predates cross-fit calibration
+and patched the selection problem with prior reweighting; this design replaces
+that with proper importance weights.
+
+## Context
+
+Tile-placement inference measures $P(\text{play} \mid L)$ for a few hundred
+leaves out of thousands and imputes the rest from marginal lifts
+(`docs/leave_imputation.md`). Two known weaknesses:
+
+1. **Shape error, never checked.** Low-order lifts miss synergies. ZIT is a
+   strong leave, but if it never appears in sampling, `lift(I)` is diluted
+   across mediocre I-leaves and imputed ZIT lands far too low. Nothing in the
+   pipeline ever compares an imputed value against a real evaluation.
+2. **Effort ignores mass.** Every draw comes from the prior, so evaluation is
+   spread over the whole space rather than concentrated where the posterior
+   says it matters.
+
+Fix: alternate measurement and imputation. Evaluate a batch, fit the model,
+impute, draw the next batch using the imputed posterior — so leaves the model
+thinks are good get formally evaluated instead of taken on faith — and repeat
+until the model stops being wrong or the budget runs out.
+
+## 1. The estimator, generalized
+
+Once the proposal stops being the prior, the current lift estimator breaks.
+`lift(S) = (wsum(S)/cnt(S)) / (wTotal/n)` is valid only because stage-1 draws
+are i.i.d. from the prior: sampling multiplicity *is* the prior weight, so
+counting each draw once gives the Hansen–Hurwitz estimator of the
+prior-weighted containment marginal. Draw from anything else and the counts
+stop tracking $P$.
+
+The estimand is a property of the leave space, not of the sampler:
+
+```math
+\mathrm{lift}(S) \;=\;
+\frac{\sum_{L \supseteq S} P(L) w(L) \big/ \sum_{L \supseteq S} P(L)}
+     {\sum_{L} P(L) w(L) \big/ \sum_{L} P(L)}
+```
+
+Estimate it with per-draw importance weights. Draw $j$ comes from proposal
+$q_{r(j)}$; give it $u_j = P(L_j)/q_{r(j)}(L_j)$ and accumulate weighted sums:
+
+```math
+\mathrm{lift}(S) = \frac{\sum_{j:\,S\subseteq L_j} u_j w_j \big/ \sum_{j:\,S\subseteq L_j} u_j}
+                        {\sum_j u_j w_j \big/ \sum_j u_j}
+```
+
+Unbiased under **any** proposal sequence — posterior-guided, uncertainty-guided,
+or MCMC. Because it is a ratio, $q$ need only be known up to a constant, which
+is what admits samplers whose stationary density is unnormalized.
+
+Shrinkage keys off effective sample size, the right notion of support once
+draws carry unequal weight:
+
+```math
+\mathrm{ESS}(S) = \frac{\left(\sum_{j:\,S\subseteq L_j} u_j\right)^2}
+                       {\sum_{j:\,S\subseteq L_j} u_j^2}
+```
+
+**Exactly backward compatible.** With $q = P$ every $u_j = 1$, so $\sum u =
+\mathrm{cnt}$, $\sum u^2 = \mathrm{cnt}$, $\mathrm{ESS} = \mathrm{cnt}$, and
+every formula collapses to today's. Round 0 behaviour is unchanged.
+
+Calibration gets the same treatment: the moment condition becomes $\sum_L U_L
+e^{C + \sum\varphi^{(-f(L))}(L)} = \sum_L U_L \bar w(L)$ with $U_L = \sum_{j:
+L_j = L} u_j$ replacing the draw count $c_L$. Cross-fitting
+(`docs/leave_imputation.md` §5) is orthogonal and carries over untouched.
+
+## 2. The proposal: exploit by weight, explore by uncertainty
+
+Round $r$ draws from the unmeasured leaves $U_r$ with
+
+```math
+q_r(L) \;\propto\; W_r(L)\,\bigl(1 + \lambda_{\text{ex}}\,\mathrm{unc}(L)\bigr),
+\qquad L \in U_r, \quad \lambda_{\text{ex}} = 1
+```
+
+where $W_r(L) = P(L)\hat\ell_r(L)$ is the current posterior weight and
+$\mathrm{unc}(L)$ is the model's own uncertainty about it. Weight alone would
+be pure exploitation; the bonus is the UCB term.
+
+**Uncertainty comes free from the shrinkage.** A term estimated from thin
+support is multiplied by $\mathrm{ESS}/(\mathrm{ESS}+\lambda)$; the part
+discarded is precisely what we do not know:
+
+```math
+\mathrm{unc}(S) =
+\begin{cases}
+\left(1 - \frac{\mathrm{ESS}(S)}{\mathrm{ESS}(S)+\lambda}\right)\bigl|\log \mathrm{lift}(S)\bigr| & \mathrm{ESS}(S) > 0\\[4pt]
+\sigma_0(|S|) & \mathrm{ESS}(S) = 0
+\end{cases}
+\qquad
+\mathrm{unc}(L) = \sqrt{\sum_{S \subseteq L} \mathrm{unc}(S)^2}
+```
+
+$\sigma_0(o)$ is the RMS of $|\log\mathrm{lift}|$ over *observed* cells of
+order $o$: a never-seen sub-multiset is the most uncertain thing in the model,
+not the least, so it inherits the typical magnitude at its order rather than
+$\varphi = 0$. Computed once per model build into `unc1/unc2/unc3`, walked by
+the same recursion as `logImputed`.
+
+Why not a defensive prior mixture (the textbook choice):
+
+- **Round 0 is already the prior.** Mixing $P$ back in re-samples the region
+  stage 0 covered hardest — common-tile leaves, where support is densest and
+  the model is already confident.
+- **It misses the motivating bug.** ZIT is mispriced because the (Z,I) pair
+  has thin support. The uncertainty bonus targets that directly; prior mixing
+  would need luck, and Z's low prior makes that luck rare.
+- **It anneals for free.** As ESS grows the bonus decays and the loop slides
+  from exploration to exploitation with no schedule.
+- **Positivity does not need it.** $W_r(L) > 0$ for every feasible leave, so
+  every leave keeps a positive draw probability regardless.
+
+The prior mixture's real job was bounding $u_j$; §2.2 handles that directly.
+
+### 2.1 Systematic PPS sampling
+
+Turn $q_r$ into $m_r$ draws by building its CDF and taking $m_r$ equally
+spaced positions from one uniform offset. Each leave is drawn $\lfloor m_r q_r
+\rfloor$ or $\lceil m_r q_r \rceil$ times, so $\mathbb{E}[n_L] = m_r q_r(L)$
+exactly — unbiased with the same $u_j$, far lower variance than i.i.d. draws,
+no accidental duplicates, and everything with $q_r \ge 1/m_r$ is measured with
+certainty.
+
+A leave drawn $n_L > 1$ times is evaluated once with its multiplicity folded
+into the weight ($n_L u_j$) rather than re-simmed. That is algebraically the
+same estimator with a slightly higher variance on $w$, and it buys coverage
+instead of precision. The alternative — actually running $n_L$ independent
+mini-sims and averaging — is worth revisiting given how noisy a single
+likelihood is (at $\tau = 0.05$ a ±0.03 win-probability error is ±0.12 in
+log-odds, which the softmax turns into a factor of $e^{0.12/0.05} \approx 11$),
+but duplicates require a leave holding $\ge 1/m_r$ of the proposal mass and are
+rare over thousands of candidates.
+
+### 2.2 Weight stability
+
+$u_j = P(L_j)/q_r(L_j)$ is unbounded only as $\hat\ell \to 0$, and such leaves
+are drawn with correspondingly tiny probability — the classic heavy-tail risk.
+Note the uncertainty bonus sits in the denominator, so exploratory draws
+already carry *smaller* weights. On top of that, truncate per round at
+$u_{\max} = \sqrt{m_r}\,\bar u$ (Ionides). Report the Pareto tail index
+$\hat k$ of the round's weights as a model-adequacy diagnostic: $\hat k > 0.7$
+means the proposal is a poor match for the target and the round's evidence
+should be treated as weak.
+
+## 3. The loop
+
+```
+round 0 (explore):  m_0 i.i.d. prior draws         — existing MC path, q_0 = P, u_j = 1
+repeat r = 1 .. R_max:
+    fit lifts from all draws (importance weighted)
+    cross-fit calibration constant C_r
+    assemble posterior: measured → prior × w̄, unmeasured → prior × ℓ̂
+    q_r ← W_r · (1 + λ_ex · unc) over unmeasured leaves
+    draw m_r leaves by systematic PPS; evaluate in parallel
+    record draws with u_j = P/q_r (truncated)
+    stop if any criterion below fires
+final: refit, recalibrate, assemble
+```
+
+Every round ends with a full refit, so a discovery in round 2 (Z+I leaves
+measure strong) raises the (Z,I) pair lift and pulls ZIT-adjacent leaves
+forward in round 3. That feedback is the reason to iterate rather than run one
+large posterior-guided batch.
+
+### Stopping criteria
+
+Whichever fires first:
+
+| Criterion | Test | Default |
+|---|---|---|
+| Max rounds | $r = R_{\max}$ | 6 |
+| Calibration converged | miscalibration below noise (see below) | — |
+| Space exhausted | $U_r = \varnothing$ | — |
+| Mass covered | unmeasured posterior mass $< \varepsilon_{\text{mass}}$ | 0.02 |
+| Budget | context deadline | `-time` |
+
+**The calibration criterion.** Before round $r$ is evaluated, the model
+predicts $\hat\ell_{r-1}(L_j)$ for each drawn leave — all previously
+unmeasured, so these are genuinely out-of-sample. After evaluation, the
+realized scale error is
+
+```math
+\hat R_r = \frac{\sum_j u_j w_j}{\sum_j u_j \hat\ell_{r-1}(L_j)}
+```
+
+the self-normalized importance-sampling estimate of the correction the imputed
+set still needs. $\hat R_r = 1$ means the model was right about the mass it
+was pointing at. Stop when the miscalibration is no longer statistically
+detectable:
+
+```math
+\left|\log \hat R_r\right| \;<\; \max\!\left(\varepsilon_{\text{floor}},\; 2\,\mathrm{SE}(\log \hat R_r)\right),
+\qquad \varepsilon_{\text{floor}} = 0.05
+```
+
+using the linearized ratio-estimator variance
+
+```math
+\widehat{\mathrm{Var}}(\hat R_r) = \frac{\sum_j u_j^2 \bigl(w_j - \hat R_r \hat\ell_{r-1}(L_j)\bigr)^2}
+                                        {\bigl(\sum_j u_j \hat\ell_{r-1}(L_j)\bigr)^2},
+\qquad \mathrm{SE}(\log \hat R_r) = \frac{\mathrm{SE}(\hat R_r)}{\hat R_r}
+```
+
+The $2\,\mathrm{SE}$ term self-calibrates against the mini-sim noise floor:
+with noisy $w$ and a small batch the SE is large and the loop stops rather
+than chasing measurement noise; with a large batch it keeps going until the
+residual bias is genuinely small. $\varepsilon_{\text{floor}}$ stops a very
+large batch from chasing a 1% effect. $\log \hat R_r$, its SE, and $\hat k$
+are logged per round, so convergence is visible.
+
+### Budget
+
+Round 0 takes `stage0Frac` (default 0.4) of the time budget; each later round
+gets an equal share of the remainder divided by the rounds left, so early
+termination hands its time back. Evaluations cost the same ~100 ms mini-sim in
+every round — the total `-time` is unchanged, only its allocation moves.
+
+## 4. Changes
+
+### `rangefinder/imputation.go` — weighted accumulator
+- `subleaveAccumulator` stores `sumU`, `sumU2`, `sumUW` per sub-multiset
+  (orders 1–3) plus totals, replacing `cnt`/`wsum`. `record(sorted, w, u)`
+  takes the draw's importance weight.
+- `buildImputationModel`: `rawLogLift = log((sumUW/sumU)/(totalUW/totalU))`,
+  shrinkage on `ESS = sumU²/sumU2`; Möbius construction, clamps and
+  `logImputed` unchanged. Also fills `unc1/unc2/unc3` and $\sigma_0$ per order.
+- `imputationModel.uncertainty(runs)` mirrors `logImputed`'s walk.
+- `measuredLeave` gains `sumU`; `calibrateLogConstant` weights by it instead
+  of `count`. `mean()` stays an unweighted mean over replicates — repeated
+  measurements of one leave are equally noisy replicates however they were
+  selected.
+- `minus`, `foldForKey`, cross-fitting: unchanged.
+- `accStats` returns ESS alongside the weighted sums for the walkthrough.
+
+### `rangefinder/refine.go` (new)
+- `evaluateLeaves(ctx, leaves, onResult)` — parallel mini-sim evaluator
+  extracted from `inferEnumerated` (`enumerate.go:183-240`), fanning out over
+  `gameCopies`/`aiplayers` with an atomic index; `inferEnumerated` becomes a
+  caller.
+- `buildProposal(res, bagMap, lambdaEx)` — weight × uncertainty bonus over
+  unmeasured leaves; returns leaves, $q$, and $u = P/q$ truncated.
+- `systematicSample(q, m, rng)` — PPS draws.
+- `refineRounds(ctx, maxRounds)` — the loop above, logging batch size,
+  $\log\hat R$, SE, $\hat k$, and remaining unmeasured mass per round.
+
+### `rangefinder/inference.go`
+- `Infer` MC branch: round 0 under a `stage0Frac` sub-deadline, then
+  `refineRounds`, then a final `finalizePlacementPosterior`.
+- `recordPlacementSample(leave, w, u)`; round 0 passes $u = 1$.
+- New fields and setters: `maxRounds` (`SetMaxRounds`, default 6),
+  `stage0Frac`, `refinedCount`, `roundLog`.
+- `inferEnumerated`: when the enumeration was truncated or timed out, fall
+  through to `refineRounds` for the remainder.
+
+### `rangefinder/stats.go`
+- Complete-posterior header gains rounds run and refined-leaf count.
+- `AnalyzeLeave` shows `measured ×n` for refined leaves automatically; the
+  walkthrough's `n` column becomes ESS.
+
+### Shell
+- `infer` spec: `-rounds N` (0 disables refinement, restoring single-stage
+  behaviour). `shell/api.go` wires it; `shell/helptext/infer.txt` documents
+  the loop.
+
+### Unchanged
+- `montecarlo/` (posterior shape identical), `ai/bot/elite.go`,
+  `cmd/inferdiag` — all inherit the loop through `Infer`.
+- Exchange inference (no imputation there).
+
+## 5. Verification
+
+| Claim | Test |
+|---|---|
+| Weighted estimator reduces to today's at $u \equiv 1$ | `TestUnitWeightsMatchCounts` |
+| Lift unbiased under a non-prior proposal | `TestWeightedLiftUnbiasedUnderSkewedProposal` |
+| Systematic PPS hits $\mathbb{E}[n_L] = m\,q(L)$ | `TestSystematicSampleExpectation` |
+| Uncertainty is highest for never-observed sub-multisets | `TestUncertaintyFavorsThinSupport` |
+| Truncation bounds the round's weights | `TestProposalWeightsTruncated` |
+| Loop converges and stops on the ratio criterion | `TestRefineRoundsConverge` |
+| Existing imputation/calibration invariants | unchanged suite |
+
+## 6. Deliberately not doing
+
+- **Shrinking measured values toward the model.** Given the noise floor, a
+  leave measured *once* may be estimated worse by its own measurement than by
+  $\hat\ell$; the principled fix is a precision-weighted blend of $\log \bar w$
+  and $\log \hat\ell$, which needs a variance model for the mini-sim
+  likelihood. PPS replicates on high-mass leaves mitigate the worst of it.
+- **Balance-heuristic (MIS) weights across rounds**, $u_j = P/\bar q$ with
+  $\bar q = \sum_r m_r q_r / \sum_r m_r$. Lower variance than per-round
+  weights, but needs a per-leaf running mixture density across rounds;
+  truncation already bounds the main risk.
+- **Horvitz–Thompson inclusion-probability weighting.** Equivalent target;
+  per-draw weights are simpler and compose across rounds without tracking
+  inclusion probabilities.

--- a/docs/leave_imputation.md
+++ b/docs/leave_imputation.md
@@ -1,0 +1,251 @@
+# Marginal-Lift Imputation: the Complete Leave Posterior
+
+`rangefinder/imputation.go`, `rangefinder/enumerate.go`, `rangefinder/stats.go`
+
+## 1. The problem
+
+Tile-placement inference asks: *given the play our opponent just made, what
+tiles are they likely holding?* Bayes' rule gives the posterior over leaves
+(the tiles kept after the play):
+
+$$
+P(L \mid \text{play}) \;\propto\; P(L) \cdot P(\text{play} \mid L)
+$$
+
+- **Prior** $P(L)$: the multivariate hypergeometric probability of drawing
+  exactly the multiset $L$ from the unseen pool
+  (`combinatorialPrior`, rangefinder/inference.go).
+- **Likelihood** $P(\text{play} \mid L)$: for a candidate leave, reconstruct
+  the opponent's full rack, generate their moves, and softmax the resulting
+  equities with temperature $\tau$; the likelihood is the softmax mass on the
+  play actually observed. Lower $\tau$ models a more optimal opponent.
+
+The likelihood is expensive — each evaluation is a movegen + equity pass (or a
+mini-sim). Within the time budget we evaluate ("measure") only a subset of the
+feasible leaves: typically a few hundred out of thousands. Historically the
+simmer bridged the gap with an ad-hoc sigmoid gate blending inferred racks
+with uniform random draws. Imputation replaces that: we build **one complete
+posterior over every feasible leave**, where measured leaves keep their
+evaluated likelihood and every unmeasured leave gets a likelihood *imputed*
+from low-order containment statistics of the measured set.
+
+## 2. Containment lifts
+
+Every evaluated sample $i$ contributes its leave $L_i$ and measured likelihood
+$w_i \ge 0$ (zero is real evidence — "this leave never produces the observed
+play" — and is recorded, not skipped). Let $\bar w = \frac{1}{n}\sum_i w_i$ be
+the global mean likelihood.
+
+For a small sub-multiset $S$ (a single tile, a pair, or a triple — possibly
+with repeats, like $\{A,A\}$), define its **containment lift**:
+
+$$
+\mathrm{lift}(S) \;=\; \frac{\mathbb{E}[\,w \mid S \subseteq L\,]}{\mathbb{E}[w]}
+\;=\; \frac{\text{wsum}(S)/\text{cnt}(S)}{\bar w}
+$$
+
+where $\text{cnt}(S)$ and $\text{wsum}(S)$ count/sum over evaluated samples
+whose leave contains $S$ (each *distinct* sub-multiset counted once per
+sample; `subleaveAccumulator.record`). Numerator and denominator share the
+same sample set, so selection noise partially cancels.
+
+Intuition: $\mathrm{lift}(Z) = 28$ means "evaluated leaves containing Z
+produced the observed play 28× more often than average" — Z is strongly
+implicated by the play.
+
+The maximum order of tracked sub-multisets is $m = \lceil k/2 \rceil$ capped
+at 3, where $k$ is the leave size (`marginalOrder`). For a 3-tile leave that
+means singles and pairs; for 5+ tiles, singles, pairs, and triples.
+
+## 3. Combining lifts: Möbius inversion on the divisor lattice
+
+The naive estimate $\log \hat\ell(L) = \sum_{t \in L} \log\mathrm{lift}(t)$
+double-counts: if I and T are *individually* fine but *jointly* poison
+(because the observed play would have used one of them), single-tile lifts
+can't see it. We want a truncated log-linear expansion where each order adds
+only the **new** information not already explained by its sub-parts.
+
+Sub-multisets of a multiset ordered by inclusion form a **divisor lattice**
+(map each tile to a distinct prime; a sub-multiset is a divisor). Interaction
+terms $\varphi$ are defined bottom-up by Möbius inversion on that lattice:
+
+$$
+\varphi(S) \;=\; \log \mathrm{lift}(S) \;-\; \sum_{\varnothing \ne T \subsetneq S} \varphi(T)
+$$
+
+For all-distinct tiles this reduces to familiar inclusion–exclusion:
+
+$$
+\varphi(\{a\}) = \log\mathrm{lift}(a), \qquad
+\varphi(\{a,b\}) = \log\mathrm{lift}(ab) - \varphi(a) - \varphi(b)
+$$
+
+but the divisor lattice handles repeats correctly, which subset-lattice
+inclusion–exclusion gets wrong. The proper sub-multisets of $\{A,A\}$ are just
+$\{A\}$ — the Möbius function of the divisor lattice is zero whenever any
+multiplicity gap is ≥ 2, so the empty set gets coefficient 0 here, not +1:
+
+$$
+\varphi(\{A,A\}) = \log\mathrm{lift}(AA) - \varphi(A)
+$$
+
+The imputed log-likelihood of a full leave $L$ (up to the calibration
+constant of §5) is the sum of $\varphi$ over all its distinct sub-multisets up
+to order $m$:
+
+$$
+\log \hat\ell(L) \;=\; C + \sum_{\substack{S \subseteq L \\ 1 \le |S| \le m}} \varphi(S)
+$$
+
+**Telescoping identity.** When $m = |L|$ and no shrinkage or clamping is
+applied, the sum telescopes exactly:
+$\sum_{S \subseteq L} \varphi(S) = \log\mathrm{lift}(L)$ — the expansion
+reproduces the full-leave lift whenever it is directly estimable
+(`TestMobiusTelescoping`). Truncating at order $m < |L|$ is precisely the
+approximation "interactions of order $> m$ are negligible."
+
+## 4. Regularization
+
+Raw lifts from thin support are noisy, so three guards apply
+(`buildImputationModel`):
+
+| Guard | Value | Effect |
+|---|---|---|
+| Shrinkage $\frac{c}{c+\lambda}$, $\lambda = 10$ | applied to every $\varphi$ | a term seen $c$ times decays toward 0 (lift 1 / no interaction) instead of adding variance; $c=10$ keeps half the signal |
+| Log-lift clamp $\pm\log 10^6 \approx \pm 13.8$ | order-1 terms and raw lifts | a sub-multiset whose every containing sample had $w=0$ would otherwise be $-\infty$; it clamps low (strong but finite negative evidence) |
+| Interaction clamp $\pm\log 10$ | order-2/3 terms, pre-shrinkage | one pair/triple can adjust the estimate by at most 10× beyond what its parts explain |
+
+A sub-multiset never observed at all ($c = 0$) keeps $\varphi = 0$: no
+evidence, no adjustment.
+
+## 5. Calibration: moment matching
+
+$\sum \varphi$ lives on the *lift* scale (relative to the average evaluated
+leave); measured likelihoods live on the raw softmax scale. A constant $C$
+aligns them. We choose $C$ by **moment matching over the measured leaves**
+(count-weighted, $w > 0$ only):
+
+$$
+\sum_i c_i \, e^{\,C + \sum\varphi(L_i)} \;=\; \sum_i c_i w_i
+\qquad\Longrightarrow\qquad
+C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i e^{\sum \varphi(L_i)}}
+$$
+
+computed with log-sum-exp for stability. Under this calibration the model
+reproduces the **arithmetic** mean of the measured likelihoods exactly
+(`TestCalibrationMomentMatched`).
+
+### Why not mean-of-logs (historical bug)
+
+The first implementation used
+$C = \operatorname{mean}_i\!\left(\log w_i - \sum\varphi(L_i)\right)$ —
+an anchor at the **geometric** mean. Bayes' rule consumes likelihoods
+linearly, so the arithmetic scale is the right one, and by Jensen's
+inequality $\mathbb{E}[\log w] \le \log \mathbb{E}[w]$, with the gap growing
+as $\sigma^2/2$ for log-scale variance $\sigma^2$. Softmax likelihoods at low
+$\tau$ are extremely right-skewed (most leaves are near-impossible, a few are
+very likely), so the gap is enormous in practice: in one real position the
+mean-of-logs constant was $-12.51$ against $\log \bar w = -5.42$ — a factor
+of ~1200. Since $C$ is shared by every imputed leaf, this didn't disturb
+rankings *among* imputed leaves, but it silently starved **all** of them of
+posterior mass relative to measured leaves (which enter with their raw
+arithmetic $w$), badly inflating the "measured mass" diagnostic and burying
+strong unmeasured leaves. Moment matching removes the bias by construction.
+
+## 6. Assembling the posterior
+
+`imputeFullPosterior` enumerates every feasible leave $L$ of size $k$
+drawable from the unseen pool (parallel recursive enumeration, prior computed
+incrementally in log space) and assigns:
+
+$$
+W(L) \;\propto\; P(L) \times
+\begin{cases}
+\overline{w}(L) & L \text{ measured, } \overline{w}(L) > 0 \\[2pt]
+\text{(excluded)} & L \text{ measured, } \overline{w}(L) = 0 \\[2pt]
+e^{\,C + \sum \varphi(S)} & L \text{ unmeasured}
+\end{cases}
+$$
+
+where $\overline{w}(L)$ is the mean over repeat evaluations of the same
+leave. Weights are normalized so the max is 1; leaves below $10^{-15}$ of the
+max are dropped (bounded total discarded mass ~$10^{-9}$). The simmer
+(`montecarlo.InferenceCompletePosterior`) then samples opponent leaves
+directly from this posterior via CDF binary search — no fallback-to-random
+gate.
+
+If there is no usable signal at all ($n = 0$ or $\sum w = 0$), every
+$\varphi$ is 0 and the posterior degrades gracefully to the prior
+(`TestImputeNoSignalIsPrior`).
+
+## 7. Worked example
+
+Real output for a 3-tile leave (order $m = 2$: singles + pairs), via
+`infer leave ITZ`:
+
+```
+  sub   n       E[lik|sub]   lift       shrink   φ          e^φ
+  I     570     0.003499     0.7902     0.983    -0.2314    0.7935
+  T     366     0.001496     0.3378     0.973    -1.056     0.3477
+  Z     72      0.1243       28.08      0.878    +2.928     18.69
+  IT    72      4.206e-05    0.009499   0.878    -2.022     0.1324
+  IZ    14      0.1419       32.06      0.583    +0.4496    1.568
+  TZ    9       0.06007      13.57      0.474    +0.3485    1.417
+  Σφ = 0.4168
+```
+
+Reading it:
+
+- **Z** is the play's smoking gun: 28× lift, well supported (72 samples), so
+  $\varphi(Z) = 0.878 \times \log 28.08 = +2.93$.
+- **IZ looks huge (32×) but adds little.** Its interaction subtracts what the
+  singles already explain: $\log 32.06 - \varphi(I) - \varphi(Z) = +0.77$,
+  shrunk by thin support (14 samples) to $+0.45$. The 32× is mostly "Z is
+  great," and Z is only credited once.
+- **IT is the hidden killer.** Leaves holding both I and T almost never
+  produce the observed play (lift 0.0095). Raw interaction
+  $\log 0.0095 - \varphi(I) - \varphi(T) = -3.37$ hits the interaction clamp
+  at $-2.30$, shrinks to $-2.02$ — a ~7.5× penalty beyond what I and T
+  individually explain.
+
+Net $e^{\Sigma\varphi} = 1.52$: ITZ is estimated ~1.5× as likely as the
+average evaluated leave — Z's pull mostly cancelled by the I, T, and IT
+evidence. Final weight is
+$P(L)\, e^{\,C + \Sigma\varphi}$ normalized by the max.
+
+## 8. Diagnostics
+
+- `infer analyze` (detailed): posterior header — measured/imputed counts,
+  measured mass, marginal order, $\tau$, effective sample size — plus the top
+  racks with their source (`measured ×n` / `imputed`).
+- `infer leave <tiles>`: the full walkthrough above (`AnalyzeLeave` /
+  `writeImputationWalkthrough`, rangefinder/stats.go), ending with the exact
+  chain `weight = prior × ℓ̂ ÷ max` that reproduces the stored weight — a
+  built-in self-check that the display matches the engine
+  (`TestImputationResultReconstructsWeights`).
+
+The model, calibration constant, and normalization max are persisted on
+`imputationResult` specifically so this replay is exact.
+
+## 9. Parameters and code map
+
+| Parameter | Value | Where |
+|---|---|---|
+| Marginal order $m$ | $\lceil k/2 \rceil$, cap 3 | `marginalOrder` |
+| Shrinkage $\lambda$ | 10 | `imputationLambda` |
+| Log-lift clamp | $\pm 13.8$ ($\approx \log 10^6$) | `maxAbsLogLift` |
+| Interaction clamp | $\pm 2.303$ ($\log 10$) | `maxAbsInteraction` |
+| Negligible-mass cutoff | $10^{-15}$ of max weight | `negligibleWeightFraction` |
+| Softmax temperature $\tau$ | configurable, default 0.05 | `SoftmaxTemperature`, `RangeFinder.SetTau` |
+
+| Concern | Code | Tests |
+|---|---|---|
+| Sub-multiset accumulation | `subleaveAccumulator.record` | `TestAccumulatorDistinctSubMultisets` |
+| Möbius terms | `buildImputationModel` | `TestMobiusTelescoping` |
+| Term enumeration for display | `subleaveTerms` | `TestSubleaveTermsSumMatchesLogImputed` |
+| Calibration | `imputeFullPosterior` (calibration block) | `TestCalibrationMomentMatched` |
+| Posterior assembly | `imputeFullPosterior` | `TestImputeFullPosteriorMeasuredExact`, `TestImputeUnmeasuredLift`, `TestImputeNoSignalIsPrior`, `TestMeasuredZeroExcluded` |
+| Weight replay | `AnalyzeLeave` | `TestImputationResultReconstructsWeights` |
+
+Known gap: exchange inference still uses the legacy Monte Carlo sampling path
+without a complete posterior; only tile-placement inference is imputed.

--- a/docs/leave_imputation.md
+++ b/docs/leave_imputation.md
@@ -8,9 +8,9 @@ Tile-placement inference asks: *given the play our opponent just made, what
 tiles are they likely holding?* Bayes' rule gives the posterior over leaves
 (the tiles kept after the play):
 
-$$
+```math
 P(L \mid \text{play}) \;\propto\; P(L) \cdot P(\text{play} \mid L)
-$$
+```
 
 - **Prior** $P(L)$: the multivariate hypergeometric probability of drawing
   exactly the multiset $L$ from the unseen pool
@@ -39,10 +39,10 @@ the global mean likelihood.
 For a small sub-multiset $S$ (a single tile, a pair, or a triple — possibly
 with repeats, like $\{A,A\}$), define its **containment lift**:
 
-$$
+```math
 \mathrm{lift}(S) \;=\; \frac{\mathbb{E}[\,w \mid S \subseteq L\,]}{\mathbb{E}[w]}
 \;=\; \frac{\text{wsum}(S)/\text{cnt}(S)}{\bar w}
-$$
+```
 
 where $\text{cnt}(S)$ and $\text{wsum}(S)$ count/sum over evaluated samples
 whose leave contains $S$ (each *distinct* sub-multiset counted once per
@@ -69,9 +69,9 @@ Sub-multisets of a multiset ordered by inclusion form a **divisor lattice**
 (map each tile to a distinct prime; a sub-multiset is a divisor). Interaction
 terms $\varphi$ are defined bottom-up by Möbius inversion on that lattice:
 
-$$
+```math
 \varphi(S) \;=\; \log \mathrm{lift}(S) \;-\; \sum_{\varnothing \ne T \subsetneq S} \varphi(T)
-$$
+```
 
 For all-distinct tiles this reduces to familiar inclusion–exclusion:
 
@@ -93,9 +93,9 @@ The imputed log-likelihood of a full leave $L$ (up to the calibration
 constant of §5) is the sum of $\varphi$ over all its distinct sub-multisets up
 to order $m$:
 
-$$
+```math
 \log \hat\ell(L) \;=\; C + \sum_{\substack{S \subseteq L \\ 1 \le |S| \le m}} \varphi(S)
-$$
+```
 
 **Telescoping identity.** When $m = |L|$ and no shrinkage or clamping is
 applied, the sum telescopes exactly:
@@ -125,11 +125,11 @@ leave); measured likelihoods live on the raw softmax scale. A constant $C$
 aligns them. We choose $C$ by **moment matching over the measured leaves**
 (count-weighted, $w > 0$ only):
 
-$$
+```math
 \sum_i c_i \, e^{\,C + \sum\varphi(L_i)} \;=\; \sum_i c_i w_i
 \qquad\Longrightarrow\qquad
 C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i e^{\sum \varphi(L_i)}}
-$$
+```
 
 computed with log-sum-exp for stability. Under this calibration the model
 reproduces the **arithmetic** mean of the measured likelihoods exactly
@@ -138,7 +138,7 @@ reproduces the **arithmetic** mean of the measured likelihoods exactly
 ### Why not mean-of-logs (historical bug)
 
 The first implementation used
-$C = \operatorname{mean}_i\!\left(\log w_i - \sum\varphi(L_i)\right)$ —
+$C = \mathrm{mean}_i \left(\log w_i - \sum\varphi(L_i)\right)$ —
 an anchor at the **geometric** mean. Bayes' rule consumes likelihoods
 linearly, so the arithmetic scale is the right one, and by Jensen's
 inequality $\mathbb{E}[\log w] \le \log \mathbb{E}[w]$, with the gap growing
@@ -158,14 +158,14 @@ strong unmeasured leaves. Moment matching removes the bias by construction.
 drawable from the unseen pool (parallel recursive enumeration, prior computed
 incrementally in log space) and assigns:
 
-$$
+```math
 W(L) \;\propto\; P(L) \times
 \begin{cases}
 \overline{w}(L) & L \text{ measured, } \overline{w}(L) > 0 \\[2pt]
 \text{(excluded)} & L \text{ measured, } \overline{w}(L) = 0 \\[2pt]
 e^{\,C + \sum \varphi(S)} & L \text{ unmeasured}
 \end{cases}
-$$
+```
 
 where $\overline{w}(L)$ is the mean over repeat evaluations of the same
 leave. Weights are normalized so the max is 1; leaves below $10^{-15}$ of the
@@ -211,7 +211,7 @@ Reading it:
 Net $e^{\Sigma\varphi} = 1.52$: ITZ is estimated ~1.5× as likely as the
 average evaluated leave — Z's pull mostly cancelled by the I, T, and IT
 evidence. Final weight is
-$P(L)\, e^{\,C + \Sigma\varphi}$ normalized by the max.
+$P(L) \cdot e^{C + \Sigma\varphi}$ normalized by the max.
 
 ## 8. Diagnostics
 

--- a/docs/leave_imputation.md
+++ b/docs/leave_imputation.md
@@ -148,8 +148,53 @@ C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i e^{\sum \varphi(L_i)}}
 where $c_i$ is the leave's total importance weight $U_L = \sum_{j: L_j = L}
 u_j$ — its draw count while everything is prior-sampled. Computed with
 log-sum-exp for stability. Under this calibration the model reproduces the
-**arithmetic** mean of the measured likelihoods exactly
-(`TestCalibrationMomentMatched`).
+**arithmetic** mean of the measured likelihoods (`TestCalibrationMomentMatched`).
+
+This target is not arbitrary: the measured leaves are i.i.d. draws from the
+prior, so $\frac{1}{n}\sum_i U_i w_i$ estimates $\mathbb{E}_{\text{prior}}[w]$
+over the *whole* leave space — which is exactly the posterior normalizer
+$\sum_L P(L)w(L)$. The moment condition is therefore a population statement,
+and the importance weights of §2 are what keep it one if the draws ever stop
+coming from the prior.
+
+### Cross-fitting
+
+$C$ is fit on measured leaves but applied to **unmeasured** ones, so the
+predictions in its denominator have to be out-of-sample. With the full-data
+model they are not: every measured leave helped set the very lifts that
+predict it. That self-fit inflates $\sum_i U_i e^{\sum\varphi(L_i)}$ and so
+biases $C$ **low** — imputed leaves get systematically too little mass.
+
+So each distinct leave is assigned by hash to one of $K = 5$ folds
+(`foldForKey`; *every* measurement of a leave lands in the same fold), and its
+prediction in the denominator comes from the model fit on the other folds:
+
+```math
+C \;=\; \log\frac{\sum_i U_i w_i}{\sum_i U_i \, e^{\sum \varphi^{(-f(i))}(L_i)}}
+```
+
+Fold complements are exact subtractions of the accumulators
+(`subleaveAccumulator.minus`), so this costs $K$ extra model builds and no
+extra sims. Degenerate folds need no special case: a complement with no data
+leaves every $\varphi$ at 0, predicts a flat $\hat\ell = 1$, and $C$ falls
+back to $\log \bar w$ — the right answer when the lifts carry no information.
+
+Measured effect on synthetic data at production-like densities (26 tile types,
+$k=3$, order 2): the cross-fit constant runs **1.02×–1.07× above** the
+in-sample one, the gap widening as the measured set thins; a real position
+with only 160 of 3431 leaves measured shows 1.12×. $K$ barely matters — $K=5$,
+$K=20$, and leave-one-out agree to within 0.02 in log space.
+
+One honest caveat: this corrects one bias, not total calibration error. The
+model's *shape* error on unseen leaves is independent, has variable sign, and
+is often larger. In individual positions the two can cancel, so the in-sample
+constant sometimes looks better on held-out leaves by accident —
+`TestCrossFitRemovesSelfFit` therefore pins the mechanism (a leave whose lifts
+come only from its own measurements) rather than a held-out win.
+
+The runtime diagnostics print both constants and their ratio (`xfit=1.03x` in
+the `infer analyze` header), which is a direct read on how much the lifts are
+fitting their own samples in a real position.
 
 ### Why not mean-of-logs (historical bug)
 
@@ -232,8 +277,10 @@ $P(L) \cdot e^{C + \Sigma\varphi}$ normalized by the max.
 ## 8. Diagnostics
 
 - `infer analyze` (detailed): posterior header — measured/imputed counts,
-  measured mass, marginal order, $\tau$, effective sample size — plus the top
-  racks with their source (`measured ×n` / `imputed`).
+  measured mass, marginal order, $\tau$, effective sample size, and `xfit`
+  (the cross-fit/in-sample calibration ratio; 1.00× means no detectable
+  self-fit) — plus the top racks with their source (`measured ×n` /
+  `imputed`).
 - `infer leave <tiles>`: the full walkthrough above (`AnalyzeLeave` /
   `writeImputationWalkthrough`, rangefinder/stats.go), ending with the exact
   chain `weight = prior × ℓ̂ ÷ max` that reproduces the stored weight — a
@@ -252,6 +299,7 @@ The model, calibration constant, and normalization max are persisted on
 | Log-lift clamp | $\pm 13.8$ ($\approx \log 10^6$) | `maxAbsLogLift` |
 | Interaction clamp | $\pm 2.303$ ($\log 10$) | `maxAbsInteraction` |
 | Negligible-mass cutoff | $10^{-15}$ of max weight | `negligibleWeightFraction` |
+| Calibration folds $K$ | 5 | `calibrationFolds`, `foldForKey` |
 | Softmax temperature $\tau$ | configurable, default 0.05 | `SoftmaxTemperature`, `RangeFinder.SetTau` |
 
 | Concern | Code | Tests |
@@ -261,7 +309,8 @@ The model, calibration constant, and normalization max are persisted on
 | Model uncertainty | `imputationModel.uncertainty` | `TestUncertaintyFavorsThinSupport` |
 | Möbius terms | `buildImputationModel` | `TestMobiusTelescoping` |
 | Term enumeration for display | `subleaveTerms` | `TestSubleaveTermsSumMatchesLogImputed` |
-| Calibration | `imputeFullPosterior` (calibration block) | `TestCalibrationMomentMatched` |
+| Calibration | `calibrateLogConstant` | `TestCalibrationMomentMatched` |
+| Cross-fitting | `foldForKey`, `subleaveAccumulator.minus` | `TestCrossFitFoldPartition`, `TestCrossFitRemovesSelfFit` |
 | Posterior assembly | `imputeFullPosterior` | `TestImputeFullPosteriorMeasuredExact`, `TestImputeUnmeasuredLift`, `TestImputeNoSignalIsPrior`, `TestMeasuredZeroExcluded` |
 | Weight replay | `AnalyzeLeave` | `TestImputationResultReconstructsWeights` |
 

--- a/docs/leave_imputation.md
+++ b/docs/leave_imputation.md
@@ -31,23 +31,37 @@ from low-order containment statistics of the measured set.
 
 ## 2. Containment lifts
 
-Every evaluated sample $i$ contributes its leave $L_i$ and measured likelihood
-$w_i \ge 0$ (zero is real evidence — "this leave never produces the observed
-play" — and is recorded, not skipped). Let $\bar w = \frac{1}{n}\sum_i w_i$ be
-the global mean likelihood.
+Every evaluated sample $j$ contributes its leave $L_j$, its measured
+likelihood $w_j \ge 0$ (zero is real evidence — "this leave never produces the
+observed play" — and is recorded, not skipped), and an **importance weight**
+$u_j = P(L_j)/q(L_j)$, where $q$ is the proposal that produced the draw.
 
 For a small sub-multiset $S$ (a single tile, a pair, or a triple — possibly
 with repeats, like $\{A,A\}$), define its **containment lift**:
 
 ```math
 \mathrm{lift}(S) \;=\; \frac{\mathbb{E}[\,w \mid S \subseteq L\,]}{\mathbb{E}[w]}
-\;=\; \frac{\text{wsum}(S)/\text{cnt}(S)}{\bar w}
+\;=\; \frac{\sum_{j:\,S \subseteq L_j} u_j w_j \big/ \sum_{j:\,S \subseteq L_j} u_j}
+           {\sum_j u_j w_j \big/ \sum_j u_j}
 ```
 
-where $\text{cnt}(S)$ and $\text{wsum}(S)$ count/sum over evaluated samples
-whose leave contains $S$ (each *distinct* sub-multiset counted once per
-sample; `subleaveAccumulator.record`). Numerator and denominator share the
-same sample set, so selection noise partially cancels.
+summing over evaluated samples whose leave contains $S$ (each *distinct*
+sub-multiset counted once per sample; `subleaveAccumulator.record`). Numerator
+and denominator share the same sample set, so selection noise partially
+cancels.
+
+**Why the weights.** Today every draw comes from the prior
+(`SetRandomRack`), so sampling multiplicity *is* prior weight and every
+$u_j = 1$: the sums degenerate to a plain count and likelihood-sum, and this
+is the estimator it has always been. That identity is exactly what breaks if
+leaves are ever drawn from anything else — counting draws equally would then
+estimate a lift under the *proposal* rather than the prior. Weighting each
+draw by $P/q$ makes the estimator target the same population quantity under
+any proposal, including MCMC-style samplers, since the lift is a ratio and $q$
+need only be known up to a constant. Shrinkage correspondingly keys off
+effective sample size $\mathrm{ESS}(S) = (\sum u)^2/\sum u^2$, which is again
+exactly the observation count when all $u_j = 1$
+(`TestUnitWeightsMatchCounts`, `TestWeightedLiftUnbiasedUnderSkewedProposal`).
 
 Intuition: $\mathrm{lift}(Z) = 28$ means "evaluated leaves containing Z
 produced the observed play 28× more often than average" — Z is strongly
@@ -131,8 +145,10 @@ aligns them. We choose $C$ by **moment matching over the measured leaves**
 C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i e^{\sum \varphi(L_i)}}
 ```
 
-computed with log-sum-exp for stability. Under this calibration the model
-reproduces the **arithmetic** mean of the measured likelihoods exactly
+where $c_i$ is the leave's total importance weight $U_L = \sum_{j: L_j = L}
+u_j$ — its draw count while everything is prior-sampled. Computed with
+log-sum-exp for stability. Under this calibration the model reproduces the
+**arithmetic** mean of the measured likelihoods exactly
 (`TestCalibrationMomentMatched`).
 
 ### Why not mean-of-logs (historical bug)
@@ -240,7 +256,9 @@ The model, calibration constant, and normalization max are persisted on
 
 | Concern | Code | Tests |
 |---|---|---|
-| Sub-multiset accumulation | `subleaveAccumulator.record` | `TestAccumulatorDistinctSubMultisets` |
+| Sub-multiset accumulation | `subleaveAccumulator.record` | `TestAccumulatorDistinctSubMultisets`, `TestUnitWeightsMatchCounts` |
+| Importance weighting | `subleaveAccumulator.record` (`u`) | `TestWeightedLiftUnbiasedUnderSkewedProposal` |
+| Model uncertainty | `imputationModel.uncertainty` | `TestUncertaintyFavorsThinSupport` |
 | Möbius terms | `buildImputationModel` | `TestMobiusTelescoping` |
 | Term enumeration for display | `subleaveTerms` | `TestSubleaveTermsSumMatchesLogImputed` |
 | Calibration | `imputeFullPosterior` (calibration block) | `TestCalibrationMomentMatched` |

--- a/docs/leave_imputation.md
+++ b/docs/leave_imputation.md
@@ -50,14 +50,14 @@ sub-multiset counted once per sample; `subleaveAccumulator.record`). Numerator
 and denominator share the same sample set, so selection noise partially
 cancels.
 
-**Why the weights.** Today every draw comes from the prior
+**Why the weights.** Round 0 draws racks i.i.d. from the prior
 (`SetRandomRack`), so sampling multiplicity *is* prior weight and every
-$u_j = 1$: the sums degenerate to a plain count and likelihood-sum, and this
-is the estimator it has always been. That identity is exactly what breaks if
-leaves are ever drawn from anything else — counting draws equally would then
-estimate a lift under the *proposal* rather than the prior. Weighting each
-draw by $P/q$ makes the estimator target the same population quantity under
-any proposal, including MCMC-style samplers, since the lift is a ratio and $q$
+$u_j = 1$: the sums degenerate to a plain count and likelihood-sum, which is
+what this file described before refinement existed. But the refine rounds
+(§10) draw from the posterior, and then counting draws equally would estimate
+a lift under the *proposal* rather than the prior. Weighting each draw by
+$P/q$ makes the estimator target the same population quantity under any
+proposal — including MCMC-style samplers, since the lift is a ratio and $q$
 need only be known up to a constant. Shrinkage correspondingly keys off
 effective sample size $\mathrm{ESS}(S) = (\sum u)^2/\sum u^2$, which is again
 exactly the observation count when all $u_j = 1$
@@ -145,24 +145,24 @@ aligns them. We choose $C$ by **moment matching over the measured leaves**
 C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i e^{\sum \varphi(L_i)}}
 ```
 
-where $c_i$ is the leave's total importance weight $U_L = \sum_{j: L_j = L}
-u_j$ — its draw count while everything is prior-sampled. Computed with
-log-sum-exp for stability. Under this calibration the model reproduces the
-**arithmetic** mean of the measured likelihoods (`TestCalibrationMomentMatched`).
+computed with log-sum-exp for stability. Under this calibration the model
+reproduces the **arithmetic** mean of the measured likelihoods
+(`TestCalibrationMomentMatched`).
 
-This target is not arbitrary: the measured leaves are i.i.d. draws from the
-prior, so $\frac{1}{n}\sum_i U_i w_i$ estimates $\mathbb{E}_{\text{prior}}[w]$
-over the *whole* leave space — which is exactly the posterior normalizer
-$\sum_L P(L)w(L)$. The moment condition is therefore a population statement,
-and the importance weights of §2 are what keep it one if the draws ever stop
-coming from the prior.
+where $c_i$ is the leave's total importance weight $U_L = \sum_{j: L_j = L}
+u_j$ — its draw count when everything was prior-sampled. This target is not
+arbitrary: $\frac{1}{n}\sum_i U_i w_i$ estimates
+$\mathbb{E}_{\text{prior}}[w]$ over the *whole* leave space, which is exactly
+the posterior normalizer $\sum_L P(L)w(L)$. The moment condition is therefore
+a population statement, and the importance weights are what keep it one when
+the draws stop coming from the prior.
 
 ### Cross-fitting
 
 $C$ is fit on measured leaves but applied to **unmeasured** ones, so the
 predictions in its denominator have to be out-of-sample. With the full-data
 model they are not: every measured leave helped set the very lifts that
-predict it. That self-fit inflates $\sum_i U_i e^{\sum\varphi(L_i)}$ and so
+predict it. That self-fit inflates $\sum_i c_i e^{\sum\varphi(L_i)}$ and so
 biases $C$ **low** — imputed leaves get systematically too little mass.
 
 So each distinct leave is assigned by hash to one of $K = 5$ folds
@@ -170,7 +170,7 @@ So each distinct leave is assigned by hash to one of $K = 5$ folds
 prediction in the denominator comes from the model fit on the other folds:
 
 ```math
-C \;=\; \log\frac{\sum_i U_i w_i}{\sum_i U_i \, e^{\sum \varphi^{(-f(i))}(L_i)}}
+C \;=\; \log\frac{\sum_i c_i w_i}{\sum_i c_i \, e^{\sum \varphi^{(-f(i))}(L_i)}}
 ```
 
 Fold complements are exact subtractions of the accumulators
@@ -181,16 +181,16 @@ back to $\log \bar w$ — the right answer when the lifts carry no information.
 
 Measured effect on synthetic data at production-like densities (26 tile types,
 $k=3$, order 2): the cross-fit constant runs **1.02×–1.07× above** the
-in-sample one, the gap widening as the measured set thins; a real position
-with only 160 of 3431 leaves measured shows 1.12×. $K$ barely matters — $K=5$,
-$K=20$, and leave-one-out agree to within 0.02 in log space.
+in-sample one, the gap widening as the measured set thins. $K$ barely matters
+— $K=5$, $K=20$, and leave-one-out agree to within 0.02 in log space.
 
 One honest caveat: this corrects one bias, not total calibration error. The
 model's *shape* error on unseen leaves is independent, has variable sign, and
 is often larger. In individual positions the two can cancel, so the in-sample
 constant sometimes looks better on held-out leaves by accident —
 `TestCrossFitRemovesSelfFit` therefore pins the mechanism (a leave whose lifts
-come only from its own measurements) rather than a held-out win.
+come only from its own measurements) rather than a held-out win. Attacking the
+shape error is what §10 is for.
 
 The runtime diagnostics print both constants and their ratio (`xfit=1.03x` in
 the `infer analyze` header), which is a direct read on how much the lifts are
@@ -276,16 +276,25 @@ $P(L) \cdot e^{C + \Sigma\varphi}$ normalized by the max.
 
 ## 8. Diagnostics
 
-- `infer analyze` (detailed): posterior header — measured/imputed counts,
-  measured mass, marginal order, $\tau$, effective sample size, and `xfit`
-  (the cross-fit/in-sample calibration ratio; 1.00× means no detectable
-  self-fit) — plus the top racks with their source (`measured ×n` /
-  `imputed`).
+- `infer details`: posterior header — measured/imputed counts, measured mass,
+  marginal order, $\tau$, effective sample size, `xfit` (the
+  cross-fit/in-sample calibration ratio; 1.00× means no detectable self-fit),
+  and the refine summary — plus the top racks with their source
+  (`measured ×n rR` / `imputed`), where `rR` is the round that measured the
+  leave: `r0` for the prior-sampled pass, `r1`+ for refinement rounds. It also
+  reports where the highest-weight *imputed* leave sits, since after
+  refinement the visible table is usually all measured.
+- `infer ranks [n] [measured|imputed]`: browse the full ranking, filtered by
+  source. Ranks are positions in the whole posterior, so `infer ranks imputed`
+  shows how far down the model's extrapolation starts.
 - `infer leave <tiles>`: the full walkthrough above (`AnalyzeLeave` /
   `writeImputationWalkthrough`, rangefinder/stats.go), ending with the exact
   chain `weight = prior × ℓ̂ ÷ max` that reproduces the stored weight — a
   built-in self-check that the display matches the engine
-  (`TestImputationResultReconstructsWeights`).
+  (`TestImputationResultReconstructsWeights`). A refined leave also shows how
+  it was selected and what the model predicted for it *before* it was
+  measured — the only out-of-sample prediction for that leave that survives,
+  since the final model has been refit on the measurement.
 
 The model, calibration constant, and normalization max are persisted on
 `imputationResult` specifically so this replay is exact.
@@ -306,6 +315,7 @@ The model, calibration constant, and normalization max are persisted on
 |---|---|---|
 | Sub-multiset accumulation | `subleaveAccumulator.record` | `TestAccumulatorDistinctSubMultisets`, `TestUnitWeightsMatchCounts` |
 | Importance weighting | `subleaveAccumulator.record` (`u`) | `TestWeightedLiftUnbiasedUnderSkewedProposal` |
+| Refinement loop | `refineRounds`, rangefinder/refine.go | `TestSystematicSampleExpectation`, `TestProposalWeightsTruncated`, `TestRatioStatistic` |
 | Model uncertainty | `imputationModel.uncertainty` | `TestUncertaintyFavorsThinSupport` |
 | Möbius terms | `buildImputationModel` | `TestMobiusTelescoping` |
 | Term enumeration for display | `subleaveTerms` | `TestSubleaveTermsSumMatchesLogImputed` |
@@ -316,3 +326,67 @@ The model, calibration constant, and normalization max are persisted on
 
 Known gap: exchange inference still uses the legacy Monte Carlo sampling path
 without a complete posterior; only tile-placement inference is imputed.
+
+## 10. Refinement: measuring what the model points at
+
+Everything above builds one posterior from one pass of prior-sampled
+evaluations. That leaves the model's *shape* error unchecked: nothing ever
+compares an imputed likelihood against a real evaluation. Refinement closes
+the loop (`rangefinder/refine.go`,
+`docs/development/iterative_inference_plan.md`).
+
+Round 0 is the prior-sampled pass above, on 40% of the time budget. Each later
+round draws leaves from the current posterior — restricted to leaves not yet
+measured — with an exploration bonus:
+
+```math
+q_r(L) \;\propto\; W_r(L)\,\bigl(1 + \lambda_{\text{ex}}\,\mathrm{unc}(L)\bigr),
+\qquad
+\mathrm{unc}(L) = \sqrt{\sum_{S \subseteq L}\mathrm{unc}(S)^2}
+```
+
+where $\mathrm{unc}(S) = (1 - \text{shrink})\,|\log\mathrm{lift}(S)|$ is the
+share of a term's raw signal that shrinkage suppressed for lack of support,
+and a sub-multiset never seen at all takes $\sigma_0$ — the RMS log-lift at its
+order — rather than the zero its $\varphi$ gets. This is the UCB analogue, and
+it targets the motivating failure directly: ZIT is mispriced precisely because
+the (Z,I) pair has thin support, which is what the bonus is largest for. As
+support accumulates the bonus decays, so the loop anneals from exploration to
+exploitation on its own.
+
+The draws are taken by systematic PPS sampling (one uniform offset, $m$ equally
+spaced positions on the CDF), which gives each leave $\lfloor m q\rfloor$ or
+$\lceil m q\rceil$ draws — unbiased, and far less variable than i.i.d. draws.
+A leave drawn more than once is evaluated once and its multiplicity folded
+into the importance weight, which is algebraically identical and saves the
+duplicate mini-sims. (This only arises for a leave holding at least $1/m$ of
+the proposal mass; over thousands of candidates it is rare.)
+
+Each round's draws enter the accumulator with $u_j = P/q_r$, truncated at
+$\sqrt{n}\,\bar u$, and the model is refit and recalibrated before the next
+round.
+
+**Stopping.** Each round yields an out-of-sample verdict on the model, since
+every leave in the batch was unmeasured when it was predicted:
+
+```math
+\hat R_r = \frac{\sum_j u_j w_j}{\sum_j u_j \hat\ell_{r-1}(L_j)}
+```
+
+The loop stops when the whole confidence interval of $\log\hat R_r$ fits inside
+±10% — an equivalence test, not a significance test, so an underpowered batch
+does *not* count as converged — or when the unmeasured leaves hold under 2% of
+the posterior, or the space is exhausted, or the rounds (default 6, `-rounds`)
+or the clock run out.
+
+Measured on the `TestInferTilePlay` position at a 30-second budget, against
+single-stage inference with the same budget:
+
+| | measured leaves | posterior mass measured |
+|---|---|---|
+| single stage (`-rounds 0`) | 698 | 49.5% |
+| 5 refine rounds | 994 | 68.8% |
+
+with per-round $\log\hat R$ of $-0.073, +0.060, -0.034, +0.004, +0.028$ — the
+imputation model is calibrated to within a few percent on the mass it points
+at, which is the first direct evidence for that we have had.

--- a/montecarlo/inference_sampling_test.go
+++ b/montecarlo/inference_sampling_test.go
@@ -1,0 +1,50 @@
+package montecarlo
+
+import (
+	"testing"
+
+	"github.com/domino14/word-golib/tilemapping"
+	"github.com/matryer/is"
+)
+
+// The precomputed CDF must sample racks proportionally to their weights and
+// never select zero-weight entries.
+func TestWeightedInferredDrawRacksCDF(t *testing.T) {
+	is := is.New(t)
+	s := &Simmer{}
+	racks := []InferredRack{
+		{Leave: []tilemapping.MachineLetter{1}, Weight: 0},
+		{Leave: []tilemapping.MachineLetter{2}, Weight: 1},
+		{Leave: []tilemapping.MachineLetter{3}, Weight: 3},
+	}
+	s.SetInferences(racks, 1, InferenceCompletePosterior)
+	is.Equal(len(s.inferenceCDF), 3)
+
+	counts := map[tilemapping.MachineLetter]int{}
+	const draws = 40000
+	for i := 0; i < draws; i++ {
+		leave, err := s.weightedInferredDrawRacks()
+		is.NoErr(err)
+		is.Equal(len(leave), 1)
+		counts[leave[0]]++
+	}
+
+	is.Equal(counts[1], 0) // zero-weight entry never selected
+	ratio := float64(counts[3]) / float64(counts[2])
+	if ratio < 2.7 || ratio > 3.3 {
+		t.Fatalf("weight-3 vs weight-1 draw ratio %v, want ≈3", ratio)
+	}
+}
+
+// All-zero weights must not install a CDF; drawing errors out instead of
+// looping or selecting arbitrarily.
+func TestWeightedInferredDrawRacksNoMass(t *testing.T) {
+	is := is.New(t)
+	s := &Simmer{}
+	s.SetInferences([]InferredRack{
+		{Leave: []tilemapping.MachineLetter{1}, Weight: 0},
+	}, 1, InferenceCompletePosterior)
+	is.Equal(len(s.inferenceCDF), 0)
+	_, err := s.weightedInferredDrawRacks()
+	is.True(err != nil)
+}

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -100,6 +100,11 @@ const (
 	// InferenceWeightedRandomTiles is deprecated. Use InferenceWeightedRandomRacks instead.
 	InferenceWeightedRandomTiles
 	InferenceWeightedRandomRacks
+	// InferenceCompletePosterior indicates the inferred racks form a complete
+	// posterior over every feasible opponent leave. The simmer samples from
+	// it on every iteration — no sigmoid-gated fallback to random racks,
+	// since there is no uncovered leave space to fall back for.
+	InferenceCompletePosterior
 )
 
 // InferredRack is a rack leave inferred from the opponent's last move,
@@ -316,6 +321,7 @@ type Simmer struct {
 	// See rangefinder.
 	inferences               []InferredRack
 	inferenceMode            InferenceMode
+	inferenceCDF             []float64 // cumulative weights over inferences, built once
 	tilesToInfer             int
 	adjustedBagProbabilities []float64
 	unseenToSimmingPlayer    map[tilemapping.MachineLetter]int
@@ -503,6 +509,20 @@ func (s *Simmer) SetInferences(racks []InferredRack, rackLength int, mode Infere
 	s.inferences = racks
 	s.tilesToInfer = rackLength
 	s.inferenceMode = mode
+	// Precompute the sampling CDF once; weightedInferredDrawRacks
+	// binary-searches it on every iteration.
+	s.inferenceCDF = nil
+	if len(racks) > 0 {
+		cdf := make([]float64, len(racks))
+		sum := 0.0
+		for i, ir := range racks {
+			sum += ir.Weight
+			cdf[i] = sum
+		}
+		if sum > 0 {
+			s.inferenceCDF = cdf
+		}
+	}
 }
 
 // SetWMP wires a WMP into every per-thread move generator that the simmer
@@ -807,11 +827,24 @@ func (s *Simmer) simSingleIteration(ctx context.Context, plies, thread int, iter
 	opp := (s.initialPlayer + 1) % g.NumPlayers()
 	rackToSet := s.knownOppRack
 	var err error
-	if s.inferenceMode != InferenceOff {
-
-		// Use a sigmoid to determine alpha: the probability of sampling from
-		// inferred racks rather than drawing a fully random rack.
-		// Fewer inferences = lower confidence in coverage = more random fallback.
+	if s.inferenceMode == InferenceCompletePosterior {
+		// The inferences cover every feasible leave with Bayesian posterior
+		// weights, so sample from them on every iteration. There is no
+		// uncovered leave space to fall back to random draws for.
+		rackToSet = nil
+		if len(s.inferenceCDF) > 0 {
+			rackToSet, err = s.weightedInferredDrawRacks()
+			if err != nil {
+				return err
+			}
+		}
+	} else if s.inferenceMode != InferenceOff {
+		// Legacy partial-sample modes (currently only exchange inference
+		// produces these): the inferred racks cover an unknown fraction of
+		// the leave space, so use a sigmoid to determine alpha: the
+		// probability of sampling from inferred racks rather than drawing a
+		// fully random rack. Fewer inferences = lower confidence in
+		// coverage = more random fallback.
 		const maxAlpha = 0.95
 		const midpoint = 10.0
 		const sigmoidScale = 5.0
@@ -1258,24 +1291,18 @@ func weightedChoice(tiles []tilemapping.MachineLetter, weights []float64) (tilem
 }
 
 func (s *Simmer) weightedInferredDrawRacks() ([]tilemapping.MachineLetter, error) {
-	if len(s.inferences) == 0 {
+	cdf := s.inferenceCDF
+	if len(cdf) == 0 {
 		return nil, errors.New("no inferences available")
 	}
-
-	// Build cumulative weights over the []InferredRack slice.
-	cumulative := make([]float64, len(s.inferences))
-	cumulative[0] = s.inferences[0].Weight
-	for i := 1; i < len(s.inferences); i++ {
-		cumulative[i] = cumulative[i-1] + s.inferences[i].Weight
+	r := rand.Float64() * cdf[len(cdf)-1]
+	// First index whose cumulative weight strictly exceeds r; strict
+	// comparison so zero-weight entries can never be selected.
+	i := sort.Search(len(cdf), func(j int) bool { return cdf[j] > r })
+	if i >= len(cdf) {
+		i = len(cdf) - 1
 	}
-
-	r := rand.Float64() * cumulative[len(cumulative)-1]
-	for i, cw := range cumulative {
-		if r < cw {
-			return s.inferences[i].Leave, nil
-		}
-	}
-	return s.inferences[len(s.inferences)-1].Leave, nil
+	return s.inferences[i].Leave, nil
 }
 
 func (s *Simmer) calculateWeightedProbabilitiesForBag() {

--- a/rangefinder/enumerate.go
+++ b/rangefinder/enumerate.go
@@ -222,18 +222,17 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 				r.simCount.Add(1)
 
 				bestPlays := simmer.BestPlays().PlaysNoLock()
-				// weight = prior * likelihood  (prior is explicit here; the sampling path omits it
-				// because SetRandomRack already draws from the prior distribution).
+				// Weight carries the measured likelihood only; the prior is
+				// applied when the complete posterior is assembled below.
+				// Zero-likelihood leaves are recorded too — they are measured
+				// evidence, not missing data, so they must not be imputed.
 				likelihoodP, _ := softmaxLikelihood(bestPlays, lastOppMove, gc.Board(), r.Tau())
-				if likelihoodP <= 0 {
-					continue
-				}
 
 				tiles := make([]tilemapping.MachineLetter, len(leaf.tiles))
 				copy(tiles, leaf.tiles)
 				results[t].racks = append(results[t].racks, montecarlo.InferredRack{
 					Leave:  tiles,
-					Weight: leaf.prior * likelihoodP,
+					Weight: likelihoodP,
 				})
 			}
 		})
@@ -243,9 +242,18 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 		return err
 	}
 
+	// Assemble the complete posterior. Evaluated leaves use prior × measured
+	// likelihood; any leaves left unevaluated (context timeout, or the
+	// low-prior tail truncated above) get imputed likelihoods from the
+	// marginal lifts of the evaluated set.
+	r.acc = newSubleaveAccumulator(len(r.inferenceBagMap), marginalOrder(r.inference.RackLength))
+	r.measured = map[string]*measuredLeave{}
 	for _, res := range results {
-		r.inference.InferredRacks = append(r.inference.InferredRacks, res.racks...)
+		for _, ir := range res.racks {
+			r.recordPlacementSample(ir.Leave, ir.Weight)
+		}
 	}
+	r.finalizePlacementPosterior()
 
 	log.Info().
 		Int("inferred-count", len(r.inference.InferredRacks)).

--- a/rangefinder/enumerate.go
+++ b/rangefinder/enumerate.go
@@ -3,15 +3,11 @@ package rangefinder
 import (
 	"context"
 	"sort"
-	"sync/atomic"
+	"sync"
+	"time"
 
 	"github.com/domino14/word-golib/tilemapping"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/domino14/macondo/ai/simplesimmer"
-	"github.com/domino14/macondo/montecarlo"
-	"github.com/domino14/macondo/move"
 )
 
 const (
@@ -133,6 +129,7 @@ func enumerateLeaves(bagMap []uint8, k int) []enumLeaf {
 // candidates are evaluated first, enabling early exit when remaining prior
 // mass is negligible.
 func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
+	start := time.Now()
 	leaves := enumerateLeaves(r.inferenceBagMap, r.inference.RackLength)
 	if len(leaves) == 0 {
 		return nil
@@ -172,74 +169,9 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 		Int("rack-length", r.inference.RackLength).
 		Msg("exhaustive-inference-start")
 
-	// Fan out over worker threads using a shared atomic index.
-	var nextIdx atomic.Int64
-	type threadResult struct {
-		racks []montecarlo.InferredRack
-	}
-	results := make([]threadResult, r.threads)
-
-	eg := errgroup.Group{}
-	for t := 0; t < r.threads; t++ {
-		t := t
-		eg.Go(func() error {
-			gc := r.gameCopies[t]
-			opp := gc.PlayerOnTurn()
-			simmer := r.aiplayers[t].(*simplesimmer.SimpleSimmer)
-
-			// fullRack is reused across iterations to avoid per-leaf allocation.
-			fullRack := make([]tilemapping.MachineLetter, len(r.lastOppMoveRackTiles)+r.inference.RackLength)
-			copy(fullRack, r.lastOppMoveRackTiles)
-
-			for {
-				i := int(nextIdx.Add(1)) - 1
-				if i >= len(leaves) {
-					return nil
-				}
-				if ctx.Err() != nil {
-					return nil
-				}
-
-				leaf := leaves[i]
-
-				// Build the full deterministic rack: played tiles + this leave.
-				// Passing a full RackTileLimit-length knownRack to SetRandomRack causes it
-				// to: (1) put back the old rack, (2) remove fullRack from the bag, (3) draw
-				// 0 additional tiles — giving us an exact, deterministic rack assignment.
-				copy(fullRack[len(r.lastOppMoveRackTiles):], leaf.tiles)
-				if _, err := gc.SetRandomRack(opp, fullRack); err != nil {
-					return err
-				}
-
-				// Copy lastOppMove and set the correct leave for this iteration.
-				lastOppMove := &move.Move{}
-				lastOppMove.CopyFrom(r.lastOppMove)
-				lastOppMove.SetLeave(leaf.tiles)
-
-				if _, err := simmer.GenAndSim(context.Background(), 10, lastOppMove); err != nil {
-					return err
-				}
-				r.simCount.Add(1)
-
-				bestPlays := simmer.BestPlays().PlaysNoLock()
-				// Weight carries the measured likelihood only; the prior is
-				// applied when the complete posterior is assembled below.
-				// Zero-likelihood leaves are recorded too — they are measured
-				// evidence, not missing data, so they must not be imputed.
-				likelihoodP, _ := softmaxLikelihood(bestPlays, lastOppMove, gc.Board(), r.Tau())
-
-				tiles := make([]tilemapping.MachineLetter, len(leaf.tiles))
-				copy(tiles, leaf.tiles)
-				results[t].racks = append(results[t].racks, montecarlo.InferredRack{
-					Leave:  tiles,
-					Weight: likelihoodP,
-				})
-			}
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return err
+	tiles := make([][]tilemapping.MachineLetter, len(leaves))
+	for i, l := range leaves {
+		tiles[i] = l.tiles
 	}
 
 	// Assemble the complete posterior. Evaluated leaves use prior × measured
@@ -247,18 +179,30 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 	// low-prior tail truncated above) get imputed likelihoods from the
 	// marginal lifts of the evaluated set.
 	r.initImputationState()
-	for _, res := range results {
-		for _, ir := range res.racks {
-			// Exhaustive enumeration visits each leave exactly once, so
-			// every draw carries unit importance weight.
-			r.recordPlacementSample(ir.Leave, ir.Weight, 1)
-		}
+	var mu sync.Mutex
+	err := r.evaluateLeaves(ctx, tiles, func(leave []tilemapping.MachineLetter, likelihood float64) {
+		// Exhaustive enumeration visits each leave exactly once, so every
+		// draw carries unit importance weight.
+		mu.Lock()
+		defer mu.Unlock()
+		r.recordPlacementSample(leave, likelihood, 1)
+	})
+	if err != nil {
+		return err
 	}
+	r.stage0Elapsed = time.Since(start)
 	r.finalizePlacementPosterior()
+
+	// If the enumeration was truncated or cut short by the deadline, the
+	// remaining leaves are imputed — so refine them with whatever budget is
+	// left. A complete enumeration leaves no candidates and this returns
+	// immediately.
+	r.refineRounds(ctx, r.MaxRounds())
 
 	log.Info().
 		Int("inferred-count", len(r.inference.InferredRacks)).
 		Uint64("sim-count", r.simCount.Load()).
+		Int("refined", r.refinedCount).
 		Msg("exhaustive-inference-done")
 
 	return nil

--- a/rangefinder/enumerate.go
+++ b/rangefinder/enumerate.go
@@ -250,7 +250,9 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 	r.measured = map[string]*measuredLeave{}
 	for _, res := range results {
 		for _, ir := range res.racks {
-			r.recordPlacementSample(ir.Leave, ir.Weight)
+			// Exhaustive enumeration visits each leave exactly once, so
+			// every draw carries unit importance weight.
+			r.recordPlacementSample(ir.Leave, ir.Weight, 1)
 		}
 	}
 	r.finalizePlacementPosterior()

--- a/rangefinder/enumerate.go
+++ b/rangefinder/enumerate.go
@@ -246,8 +246,7 @@ func (r *RangeFinder) inferEnumerated(ctx context.Context) error {
 	// likelihood; any leaves left unevaluated (context timeout, or the
 	// low-prior tail truncated above) get imputed likelihoods from the
 	// marginal lifts of the evaluated set.
-	r.acc = newSubleaveAccumulator(len(r.inferenceBagMap), marginalOrder(r.inference.RackLength))
-	r.measured = map[string]*measuredLeave{}
+	r.initImputationState()
 	for _, res := range results {
 		for _, ir := range res.racks {
 			// Exhaustive enumeration visits each leave exactly once, so

--- a/rangefinder/imputation.go
+++ b/rangefinder/imputation.go
@@ -86,34 +86,52 @@ func runsOf(sorted []tilemapping.MachineLetter, buf []tileRun) []tileRun {
 	return buf
 }
 
-// subleaveAccumulator accumulates containment-marginal statistics
-// (count and likelihood-sum) for every distinct sub-multiset of order ≤
-// maxOrder of each recorded leave. Not goroutine-safe; callers synchronize.
+// subleaveAccumulator accumulates containment-marginal statistics for every
+// distinct sub-multiset of order ≤ maxOrder of each recorded leave. Not
+// goroutine-safe; callers synchronize.
+//
+// Each draw carries an importance weight u = P(L)/q(L), where q is whatever
+// proposal produced it, so the statistics estimate prior-weighted population
+// quantities under any sampling scheme (docs/development/
+// iterative_inference_plan.md §1):
+//
+//	wt(S)   = Σ u          over draws containing S — the generalized count
+//	wtsq(S) = Σ u²         for effective sample size
+//	lik(S)  = Σ u·w
+//
+// With prior sampling every u = 1, so wt and wtsq both collapse to the raw
+// containment count and ESS = wt²/wtsq = count: the unweighted estimator is
+// the special case, not a different code path.
 type subleaveAccumulator struct {
 	alphaSize int
 	maxOrder  int
 
-	n      int     // total recorded leaves
-	wTotal float64 // total likelihood mass
+	n         int     // raw number of recorded draws
+	wtTotal   float64 // Σ u
+	wtsqTotal float64 // Σ u²
+	likTotal  float64 // Σ u·w
 
-	cnt1, wsum1 []float64 // [A], index t
-	cnt2, wsum2 []float64 // [A*A], index t*A+u with t ≤ u
-	cnt3, wsum3 []float64 // [A*A*A], index (t*A+u)*A+v with t ≤ u ≤ v
+	wt1, wtsq1, lik1 []float64 // [A], index t
+	wt2, wtsq2, lik2 []float64 // [A*A], index t*A+u with t ≤ u
+	wt3, wtsq3, lik3 []float64 // [A*A*A], index (t*A+u)*A+v with t ≤ u ≤ v
 
 	runBuf []tileRun
 }
 
 func newSubleaveAccumulator(alphaSize, maxOrder int) *subleaveAccumulator {
 	acc := &subleaveAccumulator{alphaSize: alphaSize, maxOrder: maxOrder}
-	acc.cnt1 = make([]float64, alphaSize)
-	acc.wsum1 = make([]float64, alphaSize)
+	acc.wt1 = make([]float64, alphaSize)
+	acc.wtsq1 = make([]float64, alphaSize)
+	acc.lik1 = make([]float64, alphaSize)
 	if maxOrder >= 2 {
-		acc.cnt2 = make([]float64, alphaSize*alphaSize)
-		acc.wsum2 = make([]float64, alphaSize*alphaSize)
+		acc.wt2 = make([]float64, alphaSize*alphaSize)
+		acc.wtsq2 = make([]float64, alphaSize*alphaSize)
+		acc.lik2 = make([]float64, alphaSize*alphaSize)
 	}
 	if maxOrder >= 3 {
-		acc.cnt3 = make([]float64, alphaSize*alphaSize*alphaSize)
-		acc.wsum3 = make([]float64, alphaSize*alphaSize*alphaSize)
+		acc.wt3 = make([]float64, alphaSize*alphaSize*alphaSize)
+		acc.wtsq3 = make([]float64, alphaSize*alphaSize*alphaSize)
+		acc.lik3 = make([]float64, alphaSize*alphaSize*alphaSize)
 	}
 	return acc
 }
@@ -126,55 +144,61 @@ func (acc *subleaveAccumulator) idx3(t, u, v tilemapping.MachineLetter) int {
 	return (int(t)*acc.alphaSize+int(u))*acc.alphaSize + int(v)
 }
 
+// ess returns the effective sample size of a (wt, wtsq) pair: wt²/wtsq, which
+// is the plain observation count when every draw carried weight 1.
+func ess(wt, wtsq float64) float64 {
+	if wtsq <= 0 {
+		return 0
+	}
+	return wt * wt / wtsq
+}
+
 // record adds one evaluated leave (sorted ascending) with its measured
-// likelihood w (which may be 0) to the accumulator.
-func (acc *subleaveAccumulator) record(sorted []tilemapping.MachineLetter, w float64) {
+// likelihood w (which may be 0) and its importance weight u to the
+// accumulator. Prior-sampled draws pass u = 1.
+func (acc *subleaveAccumulator) record(sorted []tilemapping.MachineLetter, w, u float64) {
 	acc.n++
-	acc.wTotal += w
+	acc.wtTotal += u
+	acc.wtsqTotal += u * u
+	acc.likTotal += u * w
 	acc.runBuf = runsOf(sorted, acc.runBuf)
 	runs := acc.runBuf
+	uu, uw := u*u, u*w
+
+	add := func(wt, wtsq, lik []float64, j int) {
+		wt[j] += u
+		wtsq[j] += uu
+		lik[j] += uw
+	}
 
 	for _, r := range runs {
-		acc.cnt1[r.t]++
-		acc.wsum1[r.t] += w
+		add(acc.wt1, acc.wtsq1, acc.lik1, int(r.t))
 	}
 	if acc.maxOrder >= 2 {
 		for i, r := range runs {
 			if r.c >= 2 {
-				j := acc.idx2(r.t, r.t)
-				acc.cnt2[j]++
-				acc.wsum2[j] += w
+				add(acc.wt2, acc.wtsq2, acc.lik2, acc.idx2(r.t, r.t))
 			}
 			for _, r2 := range runs[i+1:] {
-				j := acc.idx2(r.t, r2.t)
-				acc.cnt2[j]++
-				acc.wsum2[j] += w
+				add(acc.wt2, acc.wtsq2, acc.lik2, acc.idx2(r.t, r2.t))
 			}
 		}
 	}
 	if acc.maxOrder >= 3 {
 		for i, r := range runs {
 			if r.c >= 3 {
-				j := acc.idx3(r.t, r.t, r.t)
-				acc.cnt3[j]++
-				acc.wsum3[j] += w
+				add(acc.wt3, acc.wtsq3, acc.lik3, acc.idx3(r.t, r.t, r.t))
 			}
 			for j2 := i + 1; j2 < len(runs); j2++ {
 				r2 := runs[j2]
 				if r.c >= 2 {
-					j := acc.idx3(r.t, r.t, r2.t)
-					acc.cnt3[j]++
-					acc.wsum3[j] += w
+					add(acc.wt3, acc.wtsq3, acc.lik3, acc.idx3(r.t, r.t, r2.t))
 				}
 				if r2.c >= 2 {
-					j := acc.idx3(r.t, r2.t, r2.t)
-					acc.cnt3[j]++
-					acc.wsum3[j] += w
+					add(acc.wt3, acc.wtsq3, acc.lik3, acc.idx3(r.t, r2.t, r2.t))
 				}
 				for l := j2 + 1; l < len(runs); l++ {
-					j := acc.idx3(r.t, r2.t, runs[l].t)
-					acc.cnt3[j]++
-					acc.wsum3[j] += w
+					add(acc.wt3, acc.wtsq3, acc.lik3, acc.idx3(r.t, r2.t, runs[l].t))
 				}
 			}
 		}
@@ -182,7 +206,9 @@ func (acc *subleaveAccumulator) record(sorted []tilemapping.MachineLetter, w flo
 }
 
 // imputationModel holds the Möbius interaction terms derived from an
-// accumulator. logImputed sums them over the sub-multisets of a leave.
+// accumulator. logImputed sums them over the sub-multisets of a leave;
+// uncertainty does the same for the per-term uncertainties, which drive the
+// refine loop's exploration bonus.
 type imputationModel struct {
 	alphaSize int
 	maxOrder  int
@@ -190,9 +216,16 @@ type imputationModel struct {
 	phi2      []float64
 	phi3      []float64
 
-	lambda      float64
-	clampLift   float64
-	clampInter  float64
+	// unc* is how much of each term's raw signal was suppressed for lack of
+	// support: (1 − shrink)·|log lift|, and σ₀ for sub-multisets never seen
+	// at all. Same indexing as phi*.
+	unc1 []float64
+	unc2 []float64
+	unc3 []float64
+
+	lambda     float64
+	clampLift  float64
+	clampInter float64
 }
 
 func clampAbs(x, bound float64) float64 {
@@ -214,50 +247,72 @@ func buildImputationModel(acc *subleaveAccumulator, lambda, clampLift, clampInte
 		alphaSize:  A,
 		maxOrder:   acc.maxOrder,
 		phi1:       make([]float64, A),
+		unc1:       make([]float64, A),
 		lambda:     lambda,
 		clampLift:  clampLift,
 		clampInter: clampInter,
 	}
-	if acc.n == 0 || acc.wTotal <= 0 {
+	if acc.n == 0 || acc.likTotal <= 0 {
 		// No usable signal: all φ stay 0 and the imputed likelihood is
 		// constant, so the posterior degrades to the prior.
 		if acc.maxOrder >= 2 {
 			mod.phi2 = make([]float64, A*A)
+			mod.unc2 = make([]float64, A*A)
 		}
 		if acc.maxOrder >= 3 {
 			mod.phi3 = make([]float64, A*A*A)
+			mod.unc3 = make([]float64, A*A*A)
 		}
 		return mod
 	}
 
-	wMean := acc.wTotal / float64(acc.n)
+	// Importance-weighted global mean: Σu·w / Σu. With unit weights this is
+	// the plain sample mean.
+	wMean := acc.likTotal / acc.wtTotal
 	shrink := func(c float64) float64 {
 		return c / (c + lambda)
 	}
-	// rawLogLift = log( (wsum/cnt) / wMean ), clamped. wsum == 0 with cnt > 0
-	// is genuine "containing S kills this play" signal; it clamps low.
-	rawLogLift := func(wsum, cnt float64) float64 {
-		if wsum <= 0 {
+	// rawLogLift = log( (lik/wt) / wMean ), clamped. lik == 0 with wt > 0 is
+	// genuine "containing S kills this play" signal; it clamps low.
+	rawLogLift := func(lik, wt float64) float64 {
+		if lik <= 0 {
 			return -clampLift
 		}
-		return clampAbs(math.Log(wsum/cnt/wMean), clampLift)
+		return clampAbs(math.Log(lik/wt/wMean), clampLift)
+	}
+	// sumSq/count of |raw| per order, for the σ₀ assigned to sub-multisets
+	// never observed at all — the most uncertain terms in the model, not the
+	// least.
+	var sigSum [4]float64
+	var sigCnt [4]float64
+	// uncertainty of a term: the share of its raw signal that shrinkage
+	// suppressed for lack of support.
+	unc := func(order int, raw, e float64) float64 {
+		sigSum[order] += raw * raw
+		sigCnt[order]++
+		return (1 - shrink(e)) * math.Abs(raw)
 	}
 
 	for t := 0; t < A; t++ {
-		if acc.cnt1[t] > 0 {
-			mod.phi1[t] = shrink(acc.cnt1[t]) * rawLogLift(acc.wsum1[t], acc.cnt1[t])
+		if acc.wt1[t] > 0 {
+			e := ess(acc.wt1[t], acc.wtsq1[t])
+			raw := rawLogLift(acc.lik1[t], acc.wt1[t])
+			mod.phi1[t] = shrink(e) * raw
+			mod.unc1[t] = unc(1, raw, e)
 		}
 	}
 
 	if acc.maxOrder >= 2 {
 		mod.phi2 = make([]float64, A*A)
+		mod.unc2 = make([]float64, A*A)
 		for t := 0; t < A; t++ {
 			for u := t; u < A; u++ {
 				j := t*A + u
-				if acc.cnt2[j] == 0 {
+				if acc.wt2[j] == 0 {
 					continue
 				}
-				raw := rawLogLift(acc.wsum2[j], acc.cnt2[j])
+				e := ess(acc.wt2[j], acc.wtsq2[j])
+				raw := rawLogLift(acc.lik2[j], acc.wt2[j])
 				// Subtract φ over proper nonempty sub-multisets: {t} and, if
 				// t ≠ u, {u}. (Divisor lattice: for {t,t} the only proper
 				// nonempty sub-multiset is {t}.)
@@ -265,21 +320,25 @@ func buildImputationModel(acc *subleaveAccumulator, lambda, clampLift, clampInte
 				if u != t {
 					inter -= mod.phi1[u]
 				}
-				mod.phi2[j] = shrink(acc.cnt2[j]) * clampAbs(inter, clampInter)
+				inter = clampAbs(inter, clampInter)
+				mod.phi2[j] = shrink(e) * inter
+				mod.unc2[j] = unc(2, inter, e)
 			}
 		}
 	}
 
 	if acc.maxOrder >= 3 {
 		mod.phi3 = make([]float64, A*A*A)
+		mod.unc3 = make([]float64, A*A*A)
 		for t := 0; t < A; t++ {
 			for u := t; u < A; u++ {
 				for v := u; v < A; v++ {
 					j := (t*A+u)*A + v
-					if acc.cnt3[j] == 0 {
+					if acc.wt3[j] == 0 {
 						continue
 					}
-					raw := rawLogLift(acc.wsum3[j], acc.cnt3[j])
+					e := ess(acc.wt3[j], acc.wtsq3[j])
+					raw := rawLogLift(acc.lik3[j], acc.wt3[j])
 					// Subtract φ over all distinct proper nonempty
 					// sub-multisets of {t,u,v}.
 					var inter float64
@@ -296,12 +355,40 @@ func buildImputationModel(acc *subleaveAccumulator, lambda, clampLift, clampInte
 						inter = raw - mod.phi1[t] - mod.phi1[u] - mod.phi1[v] -
 							mod.phi2[t*A+u] - mod.phi2[t*A+v] - mod.phi2[u*A+v]
 					}
-					mod.phi3[j] = shrink(acc.cnt3[j]) * clampAbs(inter, clampInter)
+					inter = clampAbs(inter, clampInter)
+					mod.phi3[j] = shrink(e) * inter
+					mod.unc3[j] = unc(3, inter, e)
 				}
 			}
 		}
 	}
+
+	// Sub-multisets with no support at all keep φ = 0 but are the *most*
+	// uncertain terms, so they inherit σ₀: the RMS raw magnitude observed at
+	// their order (0.5 nats if nothing at that order was ever seen).
+	for order := 1; order <= mod.maxOrder; order++ {
+		sigma0 := 0.5
+		if sigCnt[order] > 0 {
+			sigma0 = math.Sqrt(sigSum[order] / sigCnt[order])
+		}
+		switch order {
+		case 1:
+			fillUnobserved(mod.unc1, acc.wt1, sigma0)
+		case 2:
+			fillUnobserved(mod.unc2, acc.wt2, sigma0)
+		case 3:
+			fillUnobserved(mod.unc3, acc.wt3, sigma0)
+		}
+	}
 	return mod
+}
+
+func fillUnobserved(unc, wt []float64, sigma0 float64) {
+	for i := range unc {
+		if wt[i] == 0 {
+			unc[i] = sigma0
+		}
+	}
 }
 
 // logImputed returns log ℓ̂(L) (up to the calibration constant) for the leave
@@ -309,41 +396,105 @@ func buildImputationModel(acc *subleaveAccumulator, lambda, clampLift, clampInte
 // order ≤ maxOrder. Its sub-multiset walk is mirrored by subleaveTerms; keep
 // the two in sync.
 func (mod *imputationModel) logImputed(runs []tileRun) float64 {
-	A := mod.alphaSize
 	s := 0.0
+	mod.walkSubleaves(runs, func(order, idx int) {
+		s += mod.phiAt(order, idx)
+	})
+	return s
+}
+
+// uncertainty returns how unsure the model is about logImputed(runs): the
+// terms' individual uncertainties combined in quadrature. It is large for
+// leaves resting on thin or absent support, which is what the refine loop's
+// exploration bonus keys off.
+func (mod *imputationModel) uncertainty(runs []tileRun) float64 {
+	s := 0.0
+	mod.walkSubleaves(runs, func(order, idx int) {
+		u := mod.uncAt(order, idx)
+		s += u * u
+	})
+	return math.Sqrt(s)
+}
+
+func (mod *imputationModel) phiAt(order, idx int) float64 {
+	switch order {
+	case 1:
+		return mod.phi1[idx]
+	case 2:
+		return mod.phi2[idx]
+	default:
+		return mod.phi3[idx]
+	}
+}
+
+func (mod *imputationModel) uncAt(order, idx int) float64 {
+	switch order {
+	case 1:
+		return mod.unc1[idx]
+	case 2:
+		return mod.unc2[idx]
+	default:
+		return mod.unc3[idx]
+	}
+}
+
+// tilesAt inverts the index packing of walkSubleaves, recovering the
+// sub-multiset itself. Diagnostic use only.
+func (mod *imputationModel) tilesAt(order, idx int) []tilemapping.MachineLetter {
+	A := mod.alphaSize
+	switch order {
+	case 1:
+		return []tilemapping.MachineLetter{tilemapping.MachineLetter(idx)}
+	case 2:
+		return []tilemapping.MachineLetter{
+			tilemapping.MachineLetter(idx / A), tilemapping.MachineLetter(idx % A)}
+	default:
+		return []tilemapping.MachineLetter{
+			tilemapping.MachineLetter(idx / (A * A)),
+			tilemapping.MachineLetter((idx / A) % A),
+			tilemapping.MachineLetter(idx % A)}
+	}
+}
+
+// walkSubleaves calls fn once for every distinct sub-multiset of order ≤
+// maxOrder of the leave described by runs, with the sub-multiset's order and
+// its index into the matching phi/unc array. This is the single definition of
+// the expansion's term set: logImputed, uncertainty and subleaveTerms all
+// drive off it, so they cannot drift apart.
+func (mod *imputationModel) walkSubleaves(runs []tileRun, fn func(order, idx int)) {
+	A := mod.alphaSize
 	for _, r := range runs {
-		s += mod.phi1[r.t]
+		fn(1, int(r.t))
 	}
 	if mod.maxOrder >= 2 {
 		for i, r := range runs {
 			if r.c >= 2 {
-				s += mod.phi2[int(r.t)*A+int(r.t)]
+				fn(2, int(r.t)*A+int(r.t))
 			}
 			for _, r2 := range runs[i+1:] {
-				s += mod.phi2[int(r.t)*A+int(r2.t)]
+				fn(2, int(r.t)*A+int(r2.t))
 			}
 		}
 	}
 	if mod.maxOrder >= 3 {
 		for i, r := range runs {
 			if r.c >= 3 {
-				s += mod.phi3[(int(r.t)*A+int(r.t))*A+int(r.t)]
+				fn(3, (int(r.t)*A+int(r.t))*A+int(r.t))
 			}
 			for j := i + 1; j < len(runs); j++ {
 				r2 := runs[j]
 				if r.c >= 2 {
-					s += mod.phi3[(int(r.t)*A+int(r.t))*A+int(r2.t)]
+					fn(3, (int(r.t)*A+int(r.t))*A+int(r2.t))
 				}
 				if r2.c >= 2 {
-					s += mod.phi3[(int(r.t)*A+int(r2.t))*A+int(r2.t)]
+					fn(3, (int(r.t)*A+int(r2.t))*A+int(r2.t))
 				}
 				for l := j + 1; l < len(runs); l++ {
-					s += mod.phi3[(int(r.t)*A+int(r2.t))*A+int(runs[l].t)]
+					fn(3, (int(r.t)*A+int(r2.t))*A+int(runs[l].t))
 				}
 			}
 		}
 	}
-	return s
 }
 
 // subleaveTerm describes one φ term contributing to logImputed.
@@ -353,82 +504,35 @@ type subleaveTerm struct {
 }
 
 // subleaveTerms enumerates every distinct sub-multiset of order ≤ maxOrder of
-// the leave described by runs, with its φ term. It mirrors the walk in
-// logImputed (keep the two in sync); it is diagnostic-only and not on the hot
-// path.
+// the leave described by runs, with its φ term. Diagnostic-only, not on the
+// hot path.
 func (mod *imputationModel) subleaveTerms(runs []tileRun) []subleaveTerm {
-	A := mod.alphaSize
 	var terms []subleaveTerm
-	for _, r := range runs {
+	mod.walkSubleaves(runs, func(order, idx int) {
 		terms = append(terms, subleaveTerm{
-			tiles: []tilemapping.MachineLetter{r.t},
-			phi:   mod.phi1[r.t],
+			tiles: mod.tilesAt(order, idx),
+			phi:   mod.phiAt(order, idx),
 		})
-	}
-	if mod.maxOrder >= 2 {
-		for i, r := range runs {
-			if r.c >= 2 {
-				terms = append(terms, subleaveTerm{
-					tiles: []tilemapping.MachineLetter{r.t, r.t},
-					phi:   mod.phi2[int(r.t)*A+int(r.t)],
-				})
-			}
-			for _, r2 := range runs[i+1:] {
-				terms = append(terms, subleaveTerm{
-					tiles: []tilemapping.MachineLetter{r.t, r2.t},
-					phi:   mod.phi2[int(r.t)*A+int(r2.t)],
-				})
-			}
-		}
-	}
-	if mod.maxOrder >= 3 {
-		for i, r := range runs {
-			if r.c >= 3 {
-				terms = append(terms, subleaveTerm{
-					tiles: []tilemapping.MachineLetter{r.t, r.t, r.t},
-					phi:   mod.phi3[(int(r.t)*A+int(r.t))*A+int(r.t)],
-				})
-			}
-			for j := i + 1; j < len(runs); j++ {
-				r2 := runs[j]
-				if r.c >= 2 {
-					terms = append(terms, subleaveTerm{
-						tiles: []tilemapping.MachineLetter{r.t, r.t, r2.t},
-						phi:   mod.phi3[(int(r.t)*A+int(r.t))*A+int(r2.t)],
-					})
-				}
-				if r2.c >= 2 {
-					terms = append(terms, subleaveTerm{
-						tiles: []tilemapping.MachineLetter{r.t, r2.t, r2.t},
-						phi:   mod.phi3[(int(r.t)*A+int(r2.t))*A+int(r2.t)],
-					})
-				}
-				for l := j + 1; l < len(runs); l++ {
-					terms = append(terms, subleaveTerm{
-						tiles: []tilemapping.MachineLetter{r.t, r2.t, runs[l].t},
-						phi:   mod.phi3[(int(r.t)*A+int(r2.t))*A+int(runs[l].t)],
-					})
-				}
-			}
-		}
-	}
+	})
 	return terms
 }
 
-// accStats returns the accumulator's raw containment stats (sample count and
-// likelihood sum) for a sorted sub-multiset of order 1–3, for diagnostics.
-func (acc *subleaveAccumulator) accStats(sub []tilemapping.MachineLetter) (cnt, wsum float64) {
+// accStats returns the accumulator's containment stats for a sorted
+// sub-multiset of order 1–3, for diagnostics: effective sample size, the
+// importance-weight total, and the weighted likelihood sum.
+func (acc *subleaveAccumulator) accStats(sub []tilemapping.MachineLetter) (e, wt, lik float64) {
 	switch len(sub) {
 	case 1:
-		return acc.cnt1[sub[0]], acc.wsum1[sub[0]]
+		t := sub[0]
+		return ess(acc.wt1[t], acc.wtsq1[t]), acc.wt1[t], acc.lik1[t]
 	case 2:
 		j := acc.idx2(sub[0], sub[1])
-		return acc.cnt2[j], acc.wsum2[j]
+		return ess(acc.wt2[j], acc.wtsq2[j]), acc.wt2[j], acc.lik2[j]
 	case 3:
 		j := acc.idx3(sub[0], sub[1], sub[2])
-		return acc.cnt3[j], acc.wsum3[j]
+		return ess(acc.wt3[j], acc.wtsq3[j]), acc.wt3[j], acc.lik3[j]
 	}
-	return 0, 0
+	return 0, 0, 0
 }
 
 // measuredLeave accumulates repeated likelihood measurements of one distinct
@@ -436,8 +540,16 @@ func (acc *subleaveAccumulator) accStats(sub []tilemapping.MachineLetter) (cnt, 
 type measuredLeave struct {
 	sumW  float64
 	count int
+	// sumU is the total importance weight of the draws that produced those
+	// measurements — the leave's weight when estimating prior-weighted
+	// quantities such as the calibration constant. It equals count for
+	// prior-sampled draws.
+	sumU float64
 }
 
+// mean is the plain average of the measurements, deliberately unweighted:
+// repeat measurements of one leave are equally noisy replicates of the same
+// quantity however the leave came to be selected.
 func (m *measuredLeave) mean() float64 {
 	if m.count == 0 {
 		return 0
@@ -479,6 +591,7 @@ func (a *tileArena) alloc(src []tilemapping.MachineLetter) []tilemapping.Machine
 // bagMap and assigns posterior weight prior(L) × likelihood(L), where the
 // likelihood is the measured mean when L was evaluated and the calibrated
 // imputed value otherwise. Weights are normalized so the max is 1.
+//
 func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
 	measured map[string]*measuredLeave, threads int) *imputationResult {
 
@@ -486,20 +599,22 @@ func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
 
 	// Calibration: measured likelihoods live on the raw softmax scale while
 	// logImputed is a sum of lift terms. Moment-match the arithmetic means:
-	// choose logCalib so that Σ c·exp(logCalib + Σφ) = Σ c·w over measured
-	// leaves. (A mean-of-logs anchor would target the geometric mean, which
-	// for heavily right-skewed likelihoods sits orders of magnitude below the
-	// arithmetic scale the lifts are estimated on, starving every imputed
-	// leaf of posterior mass relative to measured ones.)
+	// choose logCalib so that Σ U·exp(logCalib + Σφ) = Σ U·w over measured
+	// leaves, where U is the leave's total importance weight — its draw count
+	// when everything was prior-sampled. (A mean-of-logs anchor would target
+	// the geometric mean, which for heavily right-skewed likelihoods sits
+	// orders of magnitude below the arithmetic scale the lifts are estimated
+	// on, starving every imputed leaf of posterior mass relative to measured
+	// ones.)
 	logCalib := 0.0
 	{
-		var sumCW float64      // Σ c·w
-		var logCPhis []float64 // log c + Σφ per measured leave with w > 0
+		var sumUW float64      // Σ U·w
+		var logUPhis []float64 // log U + Σφ per measured leave with w > 0
 		var runBuf []tileRun
 		tiles := make([]tilemapping.MachineLetter, 0, k)
 		for key, ml := range measured {
 			w := ml.mean()
-			if w <= 0 {
+			if w <= 0 || ml.sumU <= 0 {
 				continue
 			}
 			tiles = tiles[:0]
@@ -507,23 +622,22 @@ func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
 				tiles = append(tiles, tilemapping.MachineLetter(key[i]))
 			}
 			runBuf = runsOf(tiles, runBuf)
-			sumCW += float64(ml.count) * w
-			logCPhis = append(logCPhis,
-				math.Log(float64(ml.count))+mod.logImputed(runBuf))
+			sumUW += ml.sumU * w
+			logUPhis = append(logUPhis, math.Log(ml.sumU)+mod.logImputed(runBuf))
 		}
-		if sumCW > 0 && len(logCPhis) > 0 {
-			// log Σ c·e^Σφ via log-sum-exp for stability.
+		if sumUW > 0 && len(logUPhis) > 0 {
+			// log Σ U·e^Σφ via log-sum-exp for stability.
 			maxLP := math.Inf(-1)
-			for _, lp := range logCPhis {
+			for _, lp := range logUPhis {
 				if lp > maxLP {
 					maxLP = lp
 				}
 			}
 			var expSum float64
-			for _, lp := range logCPhis {
+			for _, lp := range logUPhis {
 				expSum += math.Exp(lp - maxLP)
 			}
-			logCalib = math.Log(sumCW) - (maxLP + math.Log(expSum))
+			logCalib = math.Log(sumUW) - (maxLP + math.Log(expSum))
 		}
 	}
 

--- a/rangefinder/imputation.go
+++ b/rangefinder/imputation.go
@@ -1,0 +1,688 @@
+package rangefinder
+
+import (
+	"math"
+
+	"github.com/domino14/word-golib/tilemapping"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/domino14/macondo/montecarlo"
+)
+
+// This file implements marginal-lift imputation: from the leaves the
+// inference engine actually evaluated (each with a measured likelihood
+// P(play | leave)), we estimate low-order containment marginals and use them
+// to impute a likelihood for every feasible leave that was never evaluated.
+// The result is one complete posterior over the whole leave space, so the
+// simmer can sample opponent leaves directly from it with no ad-hoc
+// fallback-to-random gate.
+//
+// For a sub-multiset S, the "lift" is
+//
+//	lift(S) = E[likelihood | S ⊆ leave] / E[likelihood]
+//
+// estimated over the evaluated leaves (numerator and denominator share the
+// same sample set, so selection noise partially cancels). Lifts are combined
+// into a likelihood estimate with a truncated log-linear expansion whose
+// interaction terms come from Möbius inversion on the sub-multiset (divisor)
+// lattice: bottom-up, φ(S) = log lift(S) − Σ_{T⊊S, T≠∅} φ(T), which for
+// distinct tiles reduces to the familiar inclusion-exclusion forms but
+// handles repeated tiles correctly (e.g. φ({A,A}) = log lift(AA) − log
+// lift(A); the empty set gets Möbius coefficient 0 there, not +1).
+//
+// Then log ℓ̂(L) = Σ_{S ⊆ L, 1 ≤ |S| ≤ m} φ(S) over distinct sub-multisets.
+// When m = |L| and no shrinkage/clamping is applied this telescopes to
+// exactly log lift(L).
+
+const (
+	// imputationLambda is the shrinkage pseudo-count: a term estimated from c
+	// samples is scaled by c/(c+λ), so thin support decays toward 0 (lift 1 /
+	// no interaction) instead of adding variance.
+	imputationLambda = 10.0
+
+	// maxAbsLogLift clamps raw log-lifts for numerical safety (a sub-multiset
+	// whose every containing sample had likelihood 0 would otherwise be -Inf).
+	maxAbsLogLift = 13.8 // ~log(1e6)
+
+	// maxAbsInteraction clamps pair/triple interaction terms; marginal (order
+	// 1) terms are only clamped by maxAbsLogLift.
+	maxAbsInteraction = 2.302585 // log(10)
+
+	// negligibleWeightFraction drops leaves whose posterior weight, after
+	// normalization by the max weight, falls below this fraction. The total
+	// discarded mass is bounded by leafCount * this, i.e. ~1e-9 worst case.
+	negligibleWeightFraction = 1e-15
+)
+
+// marginalOrder returns the maximum sub-multiset order m estimated for leaves
+// of size k: ceil(k/2), capped at 3.
+func marginalOrder(k int) int {
+	m := (k + 1) / 2
+	if m > 3 {
+		m = 3
+	}
+	if m < 1 {
+		m = 1
+	}
+	return m
+}
+
+// tileRun is a (tile, count) run of a sorted leave.
+type tileRun struct {
+	t tilemapping.MachineLetter
+	c int
+}
+
+// runsOf collapses a sorted leave into distinct-tile runs. buf is reused.
+func runsOf(sorted []tilemapping.MachineLetter, buf []tileRun) []tileRun {
+	buf = buf[:0]
+	for _, t := range sorted {
+		if n := len(buf); n > 0 && buf[n-1].t == t {
+			buf[n-1].c++
+		} else {
+			buf = append(buf, tileRun{t: t, c: 1})
+		}
+	}
+	return buf
+}
+
+// subleaveAccumulator accumulates containment-marginal statistics
+// (count and likelihood-sum) for every distinct sub-multiset of order ≤
+// maxOrder of each recorded leave. Not goroutine-safe; callers synchronize.
+type subleaveAccumulator struct {
+	alphaSize int
+	maxOrder  int
+
+	n      int     // total recorded leaves
+	wTotal float64 // total likelihood mass
+
+	cnt1, wsum1 []float64 // [A], index t
+	cnt2, wsum2 []float64 // [A*A], index t*A+u with t ≤ u
+	cnt3, wsum3 []float64 // [A*A*A], index (t*A+u)*A+v with t ≤ u ≤ v
+
+	runBuf []tileRun
+}
+
+func newSubleaveAccumulator(alphaSize, maxOrder int) *subleaveAccumulator {
+	acc := &subleaveAccumulator{alphaSize: alphaSize, maxOrder: maxOrder}
+	acc.cnt1 = make([]float64, alphaSize)
+	acc.wsum1 = make([]float64, alphaSize)
+	if maxOrder >= 2 {
+		acc.cnt2 = make([]float64, alphaSize*alphaSize)
+		acc.wsum2 = make([]float64, alphaSize*alphaSize)
+	}
+	if maxOrder >= 3 {
+		acc.cnt3 = make([]float64, alphaSize*alphaSize*alphaSize)
+		acc.wsum3 = make([]float64, alphaSize*alphaSize*alphaSize)
+	}
+	return acc
+}
+
+func (acc *subleaveAccumulator) idx2(t, u tilemapping.MachineLetter) int {
+	return int(t)*acc.alphaSize + int(u)
+}
+
+func (acc *subleaveAccumulator) idx3(t, u, v tilemapping.MachineLetter) int {
+	return (int(t)*acc.alphaSize+int(u))*acc.alphaSize + int(v)
+}
+
+// record adds one evaluated leave (sorted ascending) with its measured
+// likelihood w (which may be 0) to the accumulator.
+func (acc *subleaveAccumulator) record(sorted []tilemapping.MachineLetter, w float64) {
+	acc.n++
+	acc.wTotal += w
+	acc.runBuf = runsOf(sorted, acc.runBuf)
+	runs := acc.runBuf
+
+	for _, r := range runs {
+		acc.cnt1[r.t]++
+		acc.wsum1[r.t] += w
+	}
+	if acc.maxOrder >= 2 {
+		for i, r := range runs {
+			if r.c >= 2 {
+				j := acc.idx2(r.t, r.t)
+				acc.cnt2[j]++
+				acc.wsum2[j] += w
+			}
+			for _, r2 := range runs[i+1:] {
+				j := acc.idx2(r.t, r2.t)
+				acc.cnt2[j]++
+				acc.wsum2[j] += w
+			}
+		}
+	}
+	if acc.maxOrder >= 3 {
+		for i, r := range runs {
+			if r.c >= 3 {
+				j := acc.idx3(r.t, r.t, r.t)
+				acc.cnt3[j]++
+				acc.wsum3[j] += w
+			}
+			for j2 := i + 1; j2 < len(runs); j2++ {
+				r2 := runs[j2]
+				if r.c >= 2 {
+					j := acc.idx3(r.t, r.t, r2.t)
+					acc.cnt3[j]++
+					acc.wsum3[j] += w
+				}
+				if r2.c >= 2 {
+					j := acc.idx3(r.t, r2.t, r2.t)
+					acc.cnt3[j]++
+					acc.wsum3[j] += w
+				}
+				for l := j2 + 1; l < len(runs); l++ {
+					j := acc.idx3(r.t, r2.t, runs[l].t)
+					acc.cnt3[j]++
+					acc.wsum3[j] += w
+				}
+			}
+		}
+	}
+}
+
+// imputationModel holds the Möbius interaction terms derived from an
+// accumulator. logImputed sums them over the sub-multisets of a leave.
+type imputationModel struct {
+	alphaSize int
+	maxOrder  int
+	phi1      []float64
+	phi2      []float64
+	phi3      []float64
+
+	lambda      float64
+	clampLift   float64
+	clampInter  float64
+}
+
+func clampAbs(x, bound float64) float64 {
+	if x > bound {
+		return bound
+	}
+	if x < -bound {
+		return -bound
+	}
+	return x
+}
+
+// buildImputationModel derives interaction terms from the accumulated
+// containment marginals. lambda/clamps are parameters so tests can disable
+// shrinkage and verify the exact Möbius telescoping identity.
+func buildImputationModel(acc *subleaveAccumulator, lambda, clampLift, clampInter float64) *imputationModel {
+	A := acc.alphaSize
+	mod := &imputationModel{
+		alphaSize:  A,
+		maxOrder:   acc.maxOrder,
+		phi1:       make([]float64, A),
+		lambda:     lambda,
+		clampLift:  clampLift,
+		clampInter: clampInter,
+	}
+	if acc.n == 0 || acc.wTotal <= 0 {
+		// No usable signal: all φ stay 0 and the imputed likelihood is
+		// constant, so the posterior degrades to the prior.
+		if acc.maxOrder >= 2 {
+			mod.phi2 = make([]float64, A*A)
+		}
+		if acc.maxOrder >= 3 {
+			mod.phi3 = make([]float64, A*A*A)
+		}
+		return mod
+	}
+
+	wMean := acc.wTotal / float64(acc.n)
+	shrink := func(c float64) float64 {
+		return c / (c + lambda)
+	}
+	// rawLogLift = log( (wsum/cnt) / wMean ), clamped. wsum == 0 with cnt > 0
+	// is genuine "containing S kills this play" signal; it clamps low.
+	rawLogLift := func(wsum, cnt float64) float64 {
+		if wsum <= 0 {
+			return -clampLift
+		}
+		return clampAbs(math.Log(wsum/cnt/wMean), clampLift)
+	}
+
+	for t := 0; t < A; t++ {
+		if acc.cnt1[t] > 0 {
+			mod.phi1[t] = shrink(acc.cnt1[t]) * rawLogLift(acc.wsum1[t], acc.cnt1[t])
+		}
+	}
+
+	if acc.maxOrder >= 2 {
+		mod.phi2 = make([]float64, A*A)
+		for t := 0; t < A; t++ {
+			for u := t; u < A; u++ {
+				j := t*A + u
+				if acc.cnt2[j] == 0 {
+					continue
+				}
+				raw := rawLogLift(acc.wsum2[j], acc.cnt2[j])
+				// Subtract φ over proper nonempty sub-multisets: {t} and, if
+				// t ≠ u, {u}. (Divisor lattice: for {t,t} the only proper
+				// nonempty sub-multiset is {t}.)
+				inter := raw - mod.phi1[t]
+				if u != t {
+					inter -= mod.phi1[u]
+				}
+				mod.phi2[j] = shrink(acc.cnt2[j]) * clampAbs(inter, clampInter)
+			}
+		}
+	}
+
+	if acc.maxOrder >= 3 {
+		mod.phi3 = make([]float64, A*A*A)
+		for t := 0; t < A; t++ {
+			for u := t; u < A; u++ {
+				for v := u; v < A; v++ {
+					j := (t*A+u)*A + v
+					if acc.cnt3[j] == 0 {
+						continue
+					}
+					raw := rawLogLift(acc.wsum3[j], acc.cnt3[j])
+					// Subtract φ over all distinct proper nonempty
+					// sub-multisets of {t,u,v}.
+					var inter float64
+					switch {
+					case t == u && u == v: // {t,t,t}: subs {t}, {t,t}
+						inter = raw - mod.phi1[t] - mod.phi2[t*A+t]
+					case t == u: // {t,t,v}: subs {t}, {v}, {t,t}, {t,v}
+						inter = raw - mod.phi1[t] - mod.phi1[v] -
+							mod.phi2[t*A+t] - mod.phi2[t*A+v]
+					case u == v: // {t,u,u}: subs {t}, {u}, {u,u}, {t,u}
+						inter = raw - mod.phi1[t] - mod.phi1[u] -
+							mod.phi2[u*A+u] - mod.phi2[t*A+u]
+					default: // all distinct
+						inter = raw - mod.phi1[t] - mod.phi1[u] - mod.phi1[v] -
+							mod.phi2[t*A+u] - mod.phi2[t*A+v] - mod.phi2[u*A+v]
+					}
+					mod.phi3[j] = shrink(acc.cnt3[j]) * clampAbs(inter, clampInter)
+				}
+			}
+		}
+	}
+	return mod
+}
+
+// logImputed returns log ℓ̂(L) (up to the calibration constant) for the leave
+// described by runs: the sum of φ over all distinct sub-multisets of L with
+// order ≤ maxOrder. Its sub-multiset walk is mirrored by subleaveTerms; keep
+// the two in sync.
+func (mod *imputationModel) logImputed(runs []tileRun) float64 {
+	A := mod.alphaSize
+	s := 0.0
+	for _, r := range runs {
+		s += mod.phi1[r.t]
+	}
+	if mod.maxOrder >= 2 {
+		for i, r := range runs {
+			if r.c >= 2 {
+				s += mod.phi2[int(r.t)*A+int(r.t)]
+			}
+			for _, r2 := range runs[i+1:] {
+				s += mod.phi2[int(r.t)*A+int(r2.t)]
+			}
+		}
+	}
+	if mod.maxOrder >= 3 {
+		for i, r := range runs {
+			if r.c >= 3 {
+				s += mod.phi3[(int(r.t)*A+int(r.t))*A+int(r.t)]
+			}
+			for j := i + 1; j < len(runs); j++ {
+				r2 := runs[j]
+				if r.c >= 2 {
+					s += mod.phi3[(int(r.t)*A+int(r.t))*A+int(r2.t)]
+				}
+				if r2.c >= 2 {
+					s += mod.phi3[(int(r.t)*A+int(r2.t))*A+int(r2.t)]
+				}
+				for l := j + 1; l < len(runs); l++ {
+					s += mod.phi3[(int(r.t)*A+int(r2.t))*A+int(runs[l].t)]
+				}
+			}
+		}
+	}
+	return s
+}
+
+// subleaveTerm describes one φ term contributing to logImputed.
+type subleaveTerm struct {
+	tiles []tilemapping.MachineLetter // the sub-multiset, e.g. [Q] or [A,Q]
+	phi   float64
+}
+
+// subleaveTerms enumerates every distinct sub-multiset of order ≤ maxOrder of
+// the leave described by runs, with its φ term. It mirrors the walk in
+// logImputed (keep the two in sync); it is diagnostic-only and not on the hot
+// path.
+func (mod *imputationModel) subleaveTerms(runs []tileRun) []subleaveTerm {
+	A := mod.alphaSize
+	var terms []subleaveTerm
+	for _, r := range runs {
+		terms = append(terms, subleaveTerm{
+			tiles: []tilemapping.MachineLetter{r.t},
+			phi:   mod.phi1[r.t],
+		})
+	}
+	if mod.maxOrder >= 2 {
+		for i, r := range runs {
+			if r.c >= 2 {
+				terms = append(terms, subleaveTerm{
+					tiles: []tilemapping.MachineLetter{r.t, r.t},
+					phi:   mod.phi2[int(r.t)*A+int(r.t)],
+				})
+			}
+			for _, r2 := range runs[i+1:] {
+				terms = append(terms, subleaveTerm{
+					tiles: []tilemapping.MachineLetter{r.t, r2.t},
+					phi:   mod.phi2[int(r.t)*A+int(r2.t)],
+				})
+			}
+		}
+	}
+	if mod.maxOrder >= 3 {
+		for i, r := range runs {
+			if r.c >= 3 {
+				terms = append(terms, subleaveTerm{
+					tiles: []tilemapping.MachineLetter{r.t, r.t, r.t},
+					phi:   mod.phi3[(int(r.t)*A+int(r.t))*A+int(r.t)],
+				})
+			}
+			for j := i + 1; j < len(runs); j++ {
+				r2 := runs[j]
+				if r.c >= 2 {
+					terms = append(terms, subleaveTerm{
+						tiles: []tilemapping.MachineLetter{r.t, r.t, r2.t},
+						phi:   mod.phi3[(int(r.t)*A+int(r.t))*A+int(r2.t)],
+					})
+				}
+				if r2.c >= 2 {
+					terms = append(terms, subleaveTerm{
+						tiles: []tilemapping.MachineLetter{r.t, r2.t, r2.t},
+						phi:   mod.phi3[(int(r.t)*A+int(r2.t))*A+int(r2.t)],
+					})
+				}
+				for l := j + 1; l < len(runs); l++ {
+					terms = append(terms, subleaveTerm{
+						tiles: []tilemapping.MachineLetter{r.t, r2.t, runs[l].t},
+						phi:   mod.phi3[(int(r.t)*A+int(r2.t))*A+int(runs[l].t)],
+					})
+				}
+			}
+		}
+	}
+	return terms
+}
+
+// accStats returns the accumulator's raw containment stats (sample count and
+// likelihood sum) for a sorted sub-multiset of order 1–3, for diagnostics.
+func (acc *subleaveAccumulator) accStats(sub []tilemapping.MachineLetter) (cnt, wsum float64) {
+	switch len(sub) {
+	case 1:
+		return acc.cnt1[sub[0]], acc.wsum1[sub[0]]
+	case 2:
+		j := acc.idx2(sub[0], sub[1])
+		return acc.cnt2[j], acc.wsum2[j]
+	case 3:
+		j := acc.idx3(sub[0], sub[1], sub[2])
+		return acc.cnt3[j], acc.wsum3[j]
+	}
+	return 0, 0
+}
+
+// measuredLeave accumulates repeated likelihood measurements of one distinct
+// leave, so the posterior uses their mean instead of first-wins.
+type measuredLeave struct {
+	sumW  float64
+	count int
+}
+
+func (m *measuredLeave) mean() float64 {
+	if m.count == 0 {
+		return 0
+	}
+	return m.sumW / float64(m.count)
+}
+
+// imputationResult is the complete posterior plus diagnostics for display.
+type imputationResult struct {
+	racks []montecarlo.InferredRack
+
+	measuredLeaves int
+	imputedLeaves  int
+	measuredMass   float64 // fraction of posterior mass on measured leaves
+	marginalOrder  int
+
+	// Retained so AnalyzeLeave can replay the calculation for any leave.
+	model    *imputationModel
+	logCalib float64
+	maxLogW  float64 // log of the pre-normalization max weight
+}
+
+// tileArena hands out small tile slices carved from large chunks, avoiding
+// one allocation per leaf when the leave space is large.
+type tileArena struct {
+	buf []tilemapping.MachineLetter
+}
+
+func (a *tileArena) alloc(src []tilemapping.MachineLetter) []tilemapping.MachineLetter {
+	if len(a.buf)+len(src) > cap(a.buf) {
+		a.buf = make([]tilemapping.MachineLetter, 0, 1<<16)
+	}
+	start := len(a.buf)
+	a.buf = append(a.buf, src...)
+	return a.buf[start:len(a.buf):len(a.buf)]
+}
+
+// imputeFullPosterior walks every feasible leave of size k drawable from
+// bagMap and assigns posterior weight prior(L) × likelihood(L), where the
+// likelihood is the measured mean when L was evaluated and the calibrated
+// imputed value otherwise. Weights are normalized so the max is 1.
+func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
+	measured map[string]*measuredLeave, threads int) *imputationResult {
+
+	mod := buildImputationModel(acc, imputationLambda, maxAbsLogLift, maxAbsInteraction)
+
+	// Calibration: measured likelihoods live on the raw softmax scale while
+	// logImputed is a sum of lift terms. Moment-match the arithmetic means:
+	// choose logCalib so that Σ c·exp(logCalib + Σφ) = Σ c·w over measured
+	// leaves. (A mean-of-logs anchor would target the geometric mean, which
+	// for heavily right-skewed likelihoods sits orders of magnitude below the
+	// arithmetic scale the lifts are estimated on, starving every imputed
+	// leaf of posterior mass relative to measured ones.)
+	logCalib := 0.0
+	{
+		var sumCW float64      // Σ c·w
+		var logCPhis []float64 // log c + Σφ per measured leave with w > 0
+		var runBuf []tileRun
+		tiles := make([]tilemapping.MachineLetter, 0, k)
+		for key, ml := range measured {
+			w := ml.mean()
+			if w <= 0 {
+				continue
+			}
+			tiles = tiles[:0]
+			for i := 0; i < len(key); i++ {
+				tiles = append(tiles, tilemapping.MachineLetter(key[i]))
+			}
+			runBuf = runsOf(tiles, runBuf)
+			sumCW += float64(ml.count) * w
+			logCPhis = append(logCPhis,
+				math.Log(float64(ml.count))+mod.logImputed(runBuf))
+		}
+		if sumCW > 0 && len(logCPhis) > 0 {
+			// log Σ c·e^Σφ via log-sum-exp for stability.
+			maxLP := math.Inf(-1)
+			for _, lp := range logCPhis {
+				if lp > maxLP {
+					maxLP = lp
+				}
+			}
+			var expSum float64
+			for _, lp := range logCPhis {
+				expSum += math.Exp(lp - maxLP)
+			}
+			logCalib = math.Log(sumCW) - (maxLP + math.Log(expSum))
+		}
+	}
+
+	N := 0
+	for _, c := range bagMap {
+		N += int(c)
+	}
+	if k <= 0 || N < k {
+		return &imputationResult{marginalOrder: acc.maxOrder, model: mod, logCalib: logCalib}
+	}
+	logChooseNK := logBinomial(N, k)
+
+	// Enumerate in parallel, splitting subtrees on the smallest tile index.
+	type scoredLeaf struct {
+		tiles    []tilemapping.MachineLetter
+		logW     float64
+		measured bool
+	}
+	perFirst := make([][]scoredLeaf, len(bagMap))
+	if threads < 1 {
+		threads = 1
+	}
+	sem := make(chan struct{}, threads)
+	eg := errgroup.Group{}
+
+	for first := 0; first < len(bagMap); first++ {
+		if bagMap[first] == 0 {
+			continue
+		}
+		first := first
+		sem <- struct{}{}
+		eg.Go(func() error {
+			defer func() { <-sem }()
+			var local []scoredLeaf
+			arena := &tileArena{}
+			buf := make([]tilemapping.MachineLetter, 0, k)
+			keyBuf := make([]byte, 0, k)
+			var runBuf []tileRun
+
+			// visit is called with buf holding a complete sorted leave and
+			// logNum = Σ_t log C(bagMap[t], count_t).
+			visit := func(logNum float64) {
+				logPrior := logNum - logChooseNK
+				keyBuf = keyBuf[:0]
+				for _, t := range buf {
+					keyBuf = append(keyBuf, byte(t))
+				}
+				var logW float64
+				isMeasured := false
+				if ml, ok := measured[string(keyBuf)]; ok {
+					isMeasured = true
+					w := ml.mean()
+					if w <= 0 {
+						return // measured to be (numerically) impossible
+					}
+					logW = logPrior + math.Log(w)
+				} else {
+					runBuf = runsOf(buf, runBuf)
+					logW = logPrior + logCalib + mod.logImputed(runBuf)
+				}
+				local = append(local, scoredLeaf{
+					tiles:    arena.alloc(buf),
+					logW:     logW,
+					measured: isMeasured,
+				})
+			}
+
+			var recurse func(minIdx, remaining int, logNum float64)
+			recurse = func(minIdx, remaining int, logNum float64) {
+				if remaining == 0 {
+					visit(logNum)
+					return
+				}
+				for i := minIdx; i < len(bagMap); i++ {
+					if bagMap[i] == 0 {
+						continue
+					}
+					maxCopies := int(bagMap[i])
+					if remaining < maxCopies {
+						maxCopies = remaining
+					}
+					prevLen := len(buf)
+					ln := logNum
+					K := float64(bagMap[i])
+					for cnt := 1; cnt <= maxCopies; cnt++ {
+						buf = append(buf, tilemapping.MachineLetter(i))
+						// C(K, cnt)/C(K, cnt-1) = (K-cnt+1)/cnt
+						ln += math.Log((K - float64(cnt) + 1) / float64(cnt))
+						recurse(i+1, remaining-cnt, ln)
+					}
+					buf = buf[:prevLen]
+				}
+			}
+
+			// The subtree rooted at `first`: take 1..maxCopies of it, then
+			// recurse over strictly larger tile indices.
+			maxCopies := int(bagMap[first])
+			if k < maxCopies {
+				maxCopies = k
+			}
+			ln := 0.0
+			K := float64(bagMap[first])
+			for cnt := 1; cnt <= maxCopies; cnt++ {
+				buf = append(buf, tilemapping.MachineLetter(first))
+				ln += math.Log((K - float64(cnt) + 1) / float64(cnt))
+				recurse(first+1, k-cnt, ln)
+			}
+
+			perFirst[first] = local
+			return nil
+		})
+	}
+	eg.Wait()
+
+	// Normalize in log space and drop negligible leaves.
+	maxLogW := math.Inf(-1)
+	total := 0
+	for _, local := range perFirst {
+		total += len(local)
+		for i := range local {
+			if local[i].logW > maxLogW {
+				maxLogW = local[i].logW
+			}
+		}
+	}
+	res := &imputationResult{
+		marginalOrder: acc.maxOrder,
+		model:         mod,
+		logCalib:      logCalib,
+		maxLogW:       maxLogW,
+	}
+	if total == 0 || math.IsInf(maxLogW, -1) {
+		return res
+	}
+	res.racks = make([]montecarlo.InferredRack, 0, total)
+	logThreshold := math.Log(negligibleWeightFraction)
+	var measuredMass, totalMass float64
+	for _, local := range perFirst {
+		for i := range local {
+			rel := local[i].logW - maxLogW
+			if rel < logThreshold {
+				continue
+			}
+			w := math.Exp(rel)
+			res.racks = append(res.racks, montecarlo.InferredRack{
+				Leave:  local[i].tiles,
+				Weight: w,
+			})
+			totalMass += w
+			if local[i].measured {
+				measuredMass += w
+				res.measuredLeaves++
+			} else {
+				res.imputedLeaves++
+			}
+		}
+	}
+	if totalMass > 0 {
+		res.measuredMass = measuredMass / totalMass
+	}
+	return res
+}

--- a/rangefinder/imputation.go
+++ b/rangefinder/imputation.go
@@ -52,7 +52,26 @@ const (
 	// normalization by the max weight, falls below this fraction. The total
 	// discarded mass is bounded by leafCount * this, i.e. ~1e-9 worst case.
 	negligibleWeightFraction = 1e-15
+
+	// calibrationFolds is the number of cross-fitting folds used to estimate
+	// the calibration constant. Each distinct measured leave is assigned to
+	// one fold; the constant is computed from predictions made by models fit
+	// on the other folds. See calibrateLogConstant.
+	calibrationFolds = 5
 )
+
+// foldForKey assigns a distinct leave (identified by its sorted-tile key) to
+// one of nFolds cross-fitting folds, by FNV-1a hash. Every measurement of the
+// same leave lands in the same fold, so a fold-complement model has never
+// seen the leave whose prediction it supplies.
+func foldForKey(key string, nFolds int) int {
+	var h uint32 = 2166136261
+	for i := 0; i < len(key); i++ {
+		h ^= uint32(key[i])
+		h *= 16777619
+	}
+	return int(h % uint32(nFolds))
+}
 
 // marginalOrder returns the maximum sub-multiset order m estimated for leaves
 // of size k: ceil(k/2), capped at 3.
@@ -203,6 +222,40 @@ func (acc *subleaveAccumulator) record(sorted []tilemapping.MachineLetter, w, u 
 			}
 		}
 	}
+}
+
+// minus returns a new accumulator holding acc's statistics with sub's
+// removed. Every field is an additive count or sum, so the complement of a
+// cross-fitting fold is an exact subtraction — no need to re-walk the
+// samples. Rounding can leave a likelihood sum a hair below zero; those are
+// clamped, since a negative mass is meaningless downstream.
+func (acc *subleaveAccumulator) minus(sub *subleaveAccumulator) *subleaveAccumulator {
+	out := newSubleaveAccumulator(acc.alphaSize, acc.maxOrder)
+	out.n = acc.n - sub.n
+	out.wtTotal = math.Max(0, acc.wtTotal-sub.wtTotal)
+	out.wtsqTotal = math.Max(0, acc.wtsqTotal-sub.wtsqTotal)
+	out.likTotal = math.Max(0, acc.likTotal-sub.likTotal)
+	subInto := func(dst, a, b []float64) {
+		for i := range dst {
+			if d := a[i] - b[i]; d > 0 {
+				dst[i] = d
+			}
+		}
+	}
+	subInto(out.wt1, acc.wt1, sub.wt1)
+	subInto(out.wtsq1, acc.wtsq1, sub.wtsq1)
+	subInto(out.lik1, acc.lik1, sub.lik1)
+	if acc.maxOrder >= 2 {
+		subInto(out.wt2, acc.wt2, sub.wt2)
+		subInto(out.wtsq2, acc.wtsq2, sub.wtsq2)
+		subInto(out.lik2, acc.lik2, sub.lik2)
+	}
+	if acc.maxOrder >= 3 {
+		subInto(out.wt3, acc.wt3, sub.wt3)
+		subInto(out.wtsq3, acc.wtsq3, sub.wtsq3)
+		subInto(out.lik3, acc.lik3, sub.lik3)
+	}
+	return out
 }
 
 // imputationModel holds the Möbius interaction terms derived from an
@@ -570,6 +623,12 @@ type imputationResult struct {
 	model    *imputationModel
 	logCalib float64
 	maxLogW  float64 // log of the pre-normalization max weight
+
+	// logCalibInSample is the constant the full-data model would have
+	// produced without cross-fitting. Diagnostic only: the gap to logCalib
+	// measures how much the lifts are fitting their own samples.
+	logCalibInSample float64
+	crossFitted      bool
 }
 
 // tileArena hands out small tile slices carved from large chunks, avoiding
@@ -587,66 +646,111 @@ func (a *tileArena) alloc(src []tilemapping.MachineLetter) []tilemapping.Machine
 	return a.buf[start:len(a.buf):len(a.buf)]
 }
 
+// logSumExp returns log Σ e^x stably. Returns -Inf for an empty slice.
+func logSumExp(xs []float64) float64 {
+	maxX := math.Inf(-1)
+	for _, x := range xs {
+		if x > maxX {
+			maxX = x
+		}
+	}
+	if math.IsInf(maxX, -1) {
+		return maxX
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += math.Exp(x - maxX)
+	}
+	return maxX + math.Log(sum)
+}
+
+// calibrateLogConstant returns the constant C that aligns the model's lift
+// scale with the raw softmax scale of the measured likelihoods. Measured
+// likelihoods live on the raw softmax scale while logImputed is a sum of lift
+// terms, so we moment-match the arithmetic means over the measured leaves:
+// choose C so that Σ U·exp(C + Σφ) = Σ U·w, where U is the leave's total
+// importance weight (its draw count under prior sampling). (A mean-of-logs anchor would
+// target the geometric mean, which for heavily right-skewed likelihoods sits
+// orders of magnitude below the arithmetic scale the lifts are estimated on,
+// starving every imputed leaf of posterior mass relative to measured ones.)
+//
+// C is fit on the measured leaves but applied to the *unmeasured* ones, so
+// the predictions entering the denominator must be out-of-sample. With the
+// full-data model they are not: every measured leave helped set the very
+// lifts that predict it, which inflates Σ c·e^Σφ and biases C low. When
+// foldModels is non-empty each leave is instead predicted by the model fit on
+// the folds excluding it (cross-fitting), which removes that self-fit. The
+// second return is the uncorrected in-sample constant, for diagnostics.
+//
+// Degenerate folds need no special case: a fold-complement model with no data
+// leaves every φ at 0, so it predicts a flat ê = 1 and C falls back to
+// log(mean w) — the right answer when the lifts carry no information.
+func calibrateLogConstant(measured map[string]*measuredLeave, k int,
+	full *imputationModel, foldModels []*imputationModel) (logCalib, inSample float64) {
+
+	var sumCW float64            // Σ U·w
+	var lpFull, lpFold []float64 // log U + Σφ per measured leave with w > 0
+	var runBuf []tileRun
+	tiles := make([]tilemapping.MachineLetter, 0, k)
+	for key, ml := range measured {
+		w := ml.mean()
+		if w <= 0 || ml.sumU <= 0 {
+			continue
+		}
+		tiles = tiles[:0]
+		for i := 0; i < len(key); i++ {
+			tiles = append(tiles, tilemapping.MachineLetter(key[i]))
+		}
+		runBuf = runsOf(tiles, runBuf)
+		logC := math.Log(ml.sumU)
+		sumCW += ml.sumU * w
+		lpFull = append(lpFull, logC+full.logImputed(runBuf))
+		if len(foldModels) > 0 {
+			lpFold = append(lpFold,
+				logC+foldModels[foldForKey(key, len(foldModels))].logImputed(runBuf))
+		}
+	}
+	if sumCW <= 0 || len(lpFull) == 0 {
+		return 0, 0
+	}
+	logSumCW := math.Log(sumCW)
+	inSample = logSumCW - logSumExp(lpFull)
+	if len(lpFold) > 0 {
+		return logSumCW - logSumExp(lpFold), inSample
+	}
+	return inSample, inSample
+}
+
 // imputeFullPosterior walks every feasible leave of size k drawable from
 // bagMap and assigns posterior weight prior(L) × likelihood(L), where the
 // likelihood is the measured mean when L was evaluated and the calibrated
 // imputed value otherwise. Weights are normalized so the max is 1.
 //
+// foldAccs, when non-nil, holds the same samples as acc partitioned by leave
+// into cross-fitting folds; it is used only to calibrate (see
+// calibrateLogConstant). The imputed likelihoods themselves always come from
+// the full-data model.
 func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
-	measured map[string]*measuredLeave, threads int) *imputationResult {
+	foldAccs []*subleaveAccumulator, measured map[string]*measuredLeave,
+	threads int) *imputationResult {
 
 	mod := buildImputationModel(acc, imputationLambda, maxAbsLogLift, maxAbsInteraction)
 
-	// Calibration: measured likelihoods live on the raw softmax scale while
-	// logImputed is a sum of lift terms. Moment-match the arithmetic means:
-	// choose logCalib so that Σ U·exp(logCalib + Σφ) = Σ U·w over measured
-	// leaves, where U is the leave's total importance weight — its draw count
-	// when everything was prior-sampled. (A mean-of-logs anchor would target
-	// the geometric mean, which for heavily right-skewed likelihoods sits
-	// orders of magnitude below the arithmetic scale the lifts are estimated
-	// on, starving every imputed leaf of posterior mass relative to measured
-	// ones.)
-	logCalib := 0.0
-	{
-		var sumUW float64      // Σ U·w
-		var logUPhis []float64 // log U + Σφ per measured leave with w > 0
-		var runBuf []tileRun
-		tiles := make([]tilemapping.MachineLetter, 0, k)
-		for key, ml := range measured {
-			w := ml.mean()
-			if w <= 0 || ml.sumU <= 0 {
-				continue
-			}
-			tiles = tiles[:0]
-			for i := 0; i < len(key); i++ {
-				tiles = append(tiles, tilemapping.MachineLetter(key[i]))
-			}
-			runBuf = runsOf(tiles, runBuf)
-			sumUW += ml.sumU * w
-			logUPhis = append(logUPhis, math.Log(ml.sumU)+mod.logImputed(runBuf))
-		}
-		if sumUW > 0 && len(logUPhis) > 0 {
-			// log Σ U·e^Σφ via log-sum-exp for stability.
-			maxLP := math.Inf(-1)
-			for _, lp := range logUPhis {
-				if lp > maxLP {
-					maxLP = lp
-				}
-			}
-			var expSum float64
-			for _, lp := range logUPhis {
-				expSum += math.Exp(lp - maxLP)
-			}
-			logCalib = math.Log(sumUW) - (maxLP + math.Log(expSum))
-		}
+	foldModels := make([]*imputationModel, 0, len(foldAccs))
+	for _, fa := range foldAccs {
+		foldModels = append(foldModels, buildImputationModel(
+			acc.minus(fa), imputationLambda, maxAbsLogLift, maxAbsInteraction))
 	}
+	logCalib, logCalibInSample := calibrateLogConstant(measured, k, mod, foldModels)
 
 	N := 0
 	for _, c := range bagMap {
 		N += int(c)
 	}
 	if k <= 0 || N < k {
-		return &imputationResult{marginalOrder: acc.maxOrder, model: mod, logCalib: logCalib}
+		return &imputationResult{marginalOrder: acc.maxOrder, model: mod,
+			logCalib: logCalib, logCalibInSample: logCalibInSample,
+			crossFitted: len(foldModels) > 0}
 	}
 	logChooseNK := logBinomial(N, k)
 
@@ -764,10 +868,12 @@ func imputeFullPosterior(bagMap []uint8, k int, acc *subleaveAccumulator,
 		}
 	}
 	res := &imputationResult{
-		marginalOrder: acc.maxOrder,
-		model:         mod,
-		logCalib:      logCalib,
-		maxLogW:       maxLogW,
+		marginalOrder:    acc.maxOrder,
+		model:            mod,
+		logCalib:         logCalib,
+		logCalibInSample: logCalibInSample,
+		crossFitted:      len(foldModels) > 0,
+		maxLogW:          maxLogW,
 	}
 	if total == 0 || math.IsInf(maxLogW, -1) {
 		return res

--- a/rangefinder/imputation.go
+++ b/rangefinder/imputation.go
@@ -598,6 +598,16 @@ type measuredLeave struct {
 	// quantities such as the calibration constant. It equals count for
 	// prior-sampled draws.
 	sumU float64
+	// round is where the leave entered the measured set: 0 for round 0
+	// (prior sampling or exhaustive enumeration), r for refine round r. A
+	// leave has exactly one origin round, since refine rounds only ever draw
+	// leaves that are still unmeasured.
+	round int
+	// predicted is the imputed likelihood the model assigned this leave just
+	// before it was measured — a genuinely out-of-sample prediction, unlike
+	// anything the final model produces for it. 0 for round-0 leaves, which
+	// were never predicted before being drawn.
+	predicted float64
 }
 
 // mean is the plain average of the measurements, deliberately unweighted:

--- a/rangefinder/imputation_test.go
+++ b/rangefinder/imputation_test.go
@@ -32,25 +32,150 @@ func TestMarginalOrder(t *testing.T) {
 func TestAccumulatorDistinctSubMultisets(t *testing.T) {
 	is := is.New(t)
 	acc := newSubleaveAccumulator(4, 3)
-	acc.record(mls(1, 1, 2), 0.5)
+	acc.record(mls(1, 1, 2), 0.5, 1)
 
 	is.Equal(acc.n, 1)
-	is.Equal(acc.wTotal, 0.5)
+	is.Equal(acc.likTotal, 0.5)
 
-	is.Equal(acc.cnt1[1], 1.0)
-	is.Equal(acc.cnt1[2], 1.0)
-	is.Equal(acc.cnt1[3], 0.0)
+	is.Equal(acc.wt1[1], 1.0)
+	is.Equal(acc.wt1[2], 1.0)
+	is.Equal(acc.wt1[3], 0.0)
 
-	is.Equal(acc.cnt2[acc.idx2(1, 1)], 1.0) // {1,1}
-	is.Equal(acc.cnt2[acc.idx2(1, 2)], 1.0) // {1,2}
-	is.Equal(acc.cnt2[acc.idx2(2, 2)], 0.0)
+	is.Equal(acc.wt2[acc.idx2(1, 1)], 1.0) // {1,1}
+	is.Equal(acc.wt2[acc.idx2(1, 2)], 1.0) // {1,2}
+	is.Equal(acc.wt2[acc.idx2(2, 2)], 0.0)
 
-	is.Equal(acc.cnt3[acc.idx3(1, 1, 2)], 1.0) // {1,1,2}
-	is.Equal(acc.cnt3[acc.idx3(1, 1, 1)], 0.0)
+	is.Equal(acc.wt3[acc.idx3(1, 1, 2)], 1.0) // {1,1,2}
+	is.Equal(acc.wt3[acc.idx3(1, 1, 1)], 0.0)
 
-	is.Equal(acc.wsum1[1], 0.5)
-	is.Equal(acc.wsum2[acc.idx2(1, 1)], 0.5)
-	is.Equal(acc.wsum3[acc.idx3(1, 1, 2)], 0.5)
+	is.Equal(acc.lik1[1], 0.5)
+	is.Equal(acc.lik2[acc.idx2(1, 1)], 0.5)
+	is.Equal(acc.lik3[acc.idx3(1, 1, 2)], 0.5)
+}
+
+// The importance-weighted accumulator must reduce exactly to plain counting
+// when every draw carries u = 1, so prior-sampled inference is bit-for-bit
+// what it was before weights existed.
+func TestUnitWeightsMatchCounts(t *testing.T) {
+	is := is.New(t)
+	acc := newSubleaveAccumulator(6, 3)
+	leaves := [][]tilemapping.MachineLetter{
+		mls(1, 2, 3), mls(1, 1, 4), mls(2, 3, 5), mls(1, 2, 3), mls(4, 4, 4),
+	}
+	for i, l := range leaves {
+		acc.record(l, 0.1*float64(i+1), 1)
+	}
+
+	// wt is the containment count, wtsq equals it, so ESS is the count.
+	for _, sub := range [][]tilemapping.MachineLetter{
+		mls(1), mls(2), mls(4), mls(1, 2), mls(4, 4), mls(1, 2, 3), mls(4, 4, 4),
+	} {
+		e, wt, _ := acc.accStats(sub)
+		is.Equal(e, wt)
+		is.Equal(wt, math.Round(wt)) // integral: it is a count
+	}
+	e, wt, lik := acc.accStats(mls(1, 2))
+	is.Equal(wt, 2.0) // leaves 0 and 3
+	is.Equal(e, 2.0)
+	is.True(math.Abs(lik-(0.1+0.4)) < 1e-12)
+	is.Equal(acc.wtTotal, 5.0)
+	is.True(math.Abs(acc.likTotal-(0.1+0.2+0.3+0.4+0.5)) < 1e-12)
+}
+
+// The lift estimator must recover the same population quantity under a
+// non-prior proposal — the whole point of importance weighting. A proposal
+// that draws some leaves more often than the prior would, corrected by
+// u = P/q, must produce exactly the prior-weighted lifts.
+//
+// The design is made deterministic by realizing the proposal as integer
+// multiplicities: leaves containing tile 1 are drawn 3× as often as the rest,
+// so q ∝ multiplicity and u = P/q. Since the accumulator is linear in u, this
+// is the exact-expectation version of that sampler, with no Monte Carlo noise
+// to tolerate.
+func TestWeightedLiftUnbiasedUnderSkewedProposal(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 4, 4, 4, 4}
+	k := 2
+	order := marginalOrder(k)
+	truth := func(tiles []tilemapping.MachineLetter) float64 {
+		w := 1.0
+		for _, tl := range tiles {
+			w *= 1.0 + 0.5*float64(tl)
+		}
+		return w
+	}
+	leaves := enumerateLeaves(bagMap, k)
+
+	// Reference: each leave once, weighted by its exact prior — the
+	// population lift with no sampling noise at all.
+	ref := newSubleaveAccumulator(len(bagMap), order)
+	for _, l := range leaves {
+		ref.record(l.tiles, truth(l.tiles), l.prior)
+	}
+
+	multOf := func(l enumLeaf) int {
+		for _, tl := range l.tiles {
+			if tl == 1 {
+				return 3
+			}
+		}
+		return 1
+	}
+	totalMult := 0
+	for _, l := range leaves {
+		totalMult += multOf(l)
+	}
+	skewed := newSubleaveAccumulator(len(bagMap), order)
+	nDraws := 0
+	for _, l := range leaves {
+		m := multOf(l)
+		q := float64(m) / float64(totalMult) // proposal probability
+		u := l.prior / q
+		for i := 0; i < m; i++ { // drawn m times by this proposal
+			skewed.record(l.tiles, truth(l.tiles), u)
+			nDraws++
+		}
+	}
+	is.True(nDraws > len(leaves)) // the proposal really is skewed
+
+	// Lifts must agree exactly. ESS differs — that is the price of the skew —
+	// so shrinkage is off for the comparison.
+	refMod := buildImputationModel(ref, 0, 1e9, 1e9)
+	skewMod := buildImputationModel(skewed, 0, 1e9, 1e9)
+	for _, l := range leaves {
+		runs := runsOf(l.tiles, nil)
+		a, b := refMod.logImputed(runs), skewMod.logImputed(runs)
+		if math.Abs(a-b) > 1e-9 {
+			t.Fatalf("leave %v: prior-weighted %v, importance-weighted %v", l.tiles, a, b)
+		}
+	}
+
+	// And the skew must cost effective sample size relative to the unweighted
+	// count, which is what shrinkage keys off.
+	e, _, _ := skewed.accStats(mls(1))
+	is.True(e < 3*float64(len(leaves)))
+}
+
+// A sub-multiset never observed is the most uncertain term in the model, not
+// the least: it must carry σ₀ rather than the zero its φ gets.
+func TestUncertaintyFavorsThinSupport(t *testing.T) {
+	is := is.New(t)
+	acc := newSubleaveAccumulator(8, 2)
+	// Tiles 1-3 richly observed; tiles 6,7 never seen.
+	for i := 0; i < 60; i++ {
+		acc.record(mls(1, 2), 1.0, 1)
+		acc.record(mls(1, 3), 3.0, 1)
+		acc.record(mls(2, 3), 0.2, 1)
+	}
+	mod := buildImputationModel(acc, imputationLambda, maxAbsLogLift, maxAbsInteraction)
+
+	wellSupported := mod.uncertainty(runsOf(mls(1, 2), nil))
+	unseen := mod.uncertainty(runsOf(mls(6, 7), nil))
+	is.True(unseen > wellSupported)
+	// The unseen pair's φ is zero, so uncertainty is the only thing that can
+	// make the refine loop look at it.
+	is.Equal(mod.logImputed(runsOf(mls(6, 7), nil)), 0.0)
+	is.True(unseen > 0)
 }
 
 // With m = k, no shrinkage, and no clamping, the Möbius expansion must
@@ -70,12 +195,12 @@ func TestMobiusTelescoping(t *testing.T) {
 	}
 	weights := []float64{8, 2, 5, 1, 3, 0.25}
 	for i, l := range leaves {
-		acc.record(l, weights[i])
+		acc.record(l, weights[i], 1)
 	}
 
 	mod := buildImputationModel(acc, 0 /* no shrinkage */, 1e9, 1e9)
 
-	wMean := acc.wTotal / float64(acc.n)
+	wMean := acc.likTotal / acc.wtTotal
 	var runBuf []tileRun
 	for i, l := range leaves {
 		runBuf = runsOf(l, runBuf)
@@ -103,7 +228,7 @@ func TestSubleaveTermsSumMatchesLogImputed(t *testing.T) {
 	}
 	weights := []float64{8, 2, 5, 1, 3, 0.25}
 	for i, l := range leaves {
-		acc.record(l, weights[i])
+		acc.record(l, weights[i], 1)
 	}
 	mod := buildImputationModel(acc, imputationLambda, maxAbsLogLift, maxAbsInteraction)
 
@@ -151,12 +276,13 @@ func TestImputationResultReconstructsWeights(t *testing.T) {
 		if holdout[key] {
 			continue
 		}
-		acc.record(l.tiles, truth(l.tiles))
+		acc.record(l.tiles, truth(l.tiles), 1)
 		if measured[key] == nil {
 			measured[key] = &measuredLeave{}
 		}
 		measured[key].sumW += truth(l.tiles)
 		measured[key].count++
+		measured[key].sumU++
 	}
 
 	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
@@ -208,12 +334,13 @@ func TestCalibrationMomentMatched(t *testing.T) {
 		if holdout[key] {
 			continue
 		}
-		acc.record(l.tiles, truth(l.tiles))
+		acc.record(l.tiles, truth(l.tiles), 1)
 		if measured[key] == nil {
 			measured[key] = &measuredLeave{}
 		}
 		measured[key].sumW += truth(l.tiles)
 		measured[key].count++
+		measured[key].sumU++
 	}
 
 	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
@@ -240,6 +367,8 @@ func TestCalibrationMomentMatched(t *testing.T) {
 	}
 }
 
+
+
 // A fully-measured leave space reproduces exact Bayesian weights:
 // posterior ∝ prior × measured likelihood.
 func TestImputeFullPosteriorMeasuredExact(t *testing.T) {
@@ -261,13 +390,14 @@ func TestImputeFullPosteriorMeasuredExact(t *testing.T) {
 	}
 	for _, l := range leaves {
 		w := likelihood(l.tiles)
-		acc.record(l.tiles, w)
+		acc.record(l.tiles, w, 1)
 		key := leaveKey(l.tiles)
 		if measured[key] == nil {
 			measured[key] = &measuredLeave{}
 		}
 		measured[key].sumW += w
 		measured[key].count++
+		measured[key].sumU++
 	}
 
 	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
@@ -335,7 +465,7 @@ func TestImputeUnmeasuredLift(t *testing.T) {
 		}
 		// Record repeatedly so shrinkage (λ=10) has little effect.
 		for rep := 0; rep < 30; rep++ {
-			acc.record(l.tiles, truth(l.tiles))
+			acc.record(l.tiles, truth(l.tiles), 1)
 		}
 		if measured[key] == nil {
 			measured[key] = &measuredLeave{}
@@ -402,9 +532,9 @@ func TestMeasuredZeroExcluded(t *testing.T) {
 	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
 	measured := map[string]*measuredLeave{}
 
-	acc.record(mls(1), 1.0)
+	acc.record(mls(1), 1.0, 1)
 	measured[leaveKey(mls(1))] = &measuredLeave{sumW: 1.0, count: 1}
-	acc.record(mls(2), 0.0)
+	acc.record(mls(2), 0.0, 1)
 	measured[leaveKey(mls(2))] = &measuredLeave{sumW: 0.0, count: 1}
 
 	res := imputeFullPosterior(bagMap, k, acc, measured, 1)
@@ -440,13 +570,14 @@ func BenchmarkImputeFullPosteriorK6(b *testing.B) {
 		// record sorts in place.
 		acc0 := l
 		sortMLs(acc0)
-		acc.record(acc0, w)
+		acc.record(acc0, w, 1)
 		key := leaveKey(acc0)
 		if measured[key] == nil {
 			measured[key] = &measuredLeave{}
 		}
 		measured[key].sumW += w
 		measured[key].count++
+		measured[key].sumU++
 	}
 
 	b.ResetTimer()

--- a/rangefinder/imputation_test.go
+++ b/rangefinder/imputation_test.go
@@ -1,0 +1,467 @@
+package rangefinder
+
+import (
+	"math"
+	"testing"
+
+	"github.com/domino14/word-golib/tilemapping"
+	"github.com/matryer/is"
+)
+
+func mls(ts ...int) []tilemapping.MachineLetter {
+	out := make([]tilemapping.MachineLetter, len(ts))
+	for i, t := range ts {
+		out[i] = tilemapping.MachineLetter(t)
+	}
+	return out
+}
+
+func TestMarginalOrder(t *testing.T) {
+	is := is.New(t)
+	is.Equal(marginalOrder(1), 1)
+	is.Equal(marginalOrder(2), 1)
+	is.Equal(marginalOrder(3), 2)
+	is.Equal(marginalOrder(4), 2)
+	is.Equal(marginalOrder(5), 3)
+	is.Equal(marginalOrder(6), 3)
+	is.Equal(marginalOrder(7), 3)
+}
+
+// Each distinct sub-multiset of a recorded leave is counted exactly once,
+// including with repeated tiles.
+func TestAccumulatorDistinctSubMultisets(t *testing.T) {
+	is := is.New(t)
+	acc := newSubleaveAccumulator(4, 3)
+	acc.record(mls(1, 1, 2), 0.5)
+
+	is.Equal(acc.n, 1)
+	is.Equal(acc.wTotal, 0.5)
+
+	is.Equal(acc.cnt1[1], 1.0)
+	is.Equal(acc.cnt1[2], 1.0)
+	is.Equal(acc.cnt1[3], 0.0)
+
+	is.Equal(acc.cnt2[acc.idx2(1, 1)], 1.0) // {1,1}
+	is.Equal(acc.cnt2[acc.idx2(1, 2)], 1.0) // {1,2}
+	is.Equal(acc.cnt2[acc.idx2(2, 2)], 0.0)
+
+	is.Equal(acc.cnt3[acc.idx3(1, 1, 2)], 1.0) // {1,1,2}
+	is.Equal(acc.cnt3[acc.idx3(1, 1, 1)], 0.0)
+
+	is.Equal(acc.wsum1[1], 0.5)
+	is.Equal(acc.wsum2[acc.idx2(1, 1)], 0.5)
+	is.Equal(acc.wsum3[acc.idx3(1, 1, 2)], 0.5)
+}
+
+// With m = k, no shrinkage, and no clamping, the Möbius expansion must
+// telescope: logImputed(L) equals the raw log-lift of L itself. This
+// exercises the divisor-lattice Möbius handling for repeated tiles
+// ({1,1,2}, {1,1,1}) as well as the all-distinct case.
+func TestMobiusTelescoping(t *testing.T) {
+	acc := newSubleaveAccumulator(5, 3)
+
+	leaves := [][]tilemapping.MachineLetter{
+		mls(1, 2, 3),
+		mls(1, 1, 2),
+		mls(1, 1, 1),
+		mls(2, 3, 3),
+		mls(1, 3, 4),
+		mls(2, 2, 4),
+	}
+	weights := []float64{8, 2, 5, 1, 3, 0.25}
+	for i, l := range leaves {
+		acc.record(l, weights[i])
+	}
+
+	mod := buildImputationModel(acc, 0 /* no shrinkage */, 1e9, 1e9)
+
+	wMean := acc.wTotal / float64(acc.n)
+	var runBuf []tileRun
+	for i, l := range leaves {
+		runBuf = runsOf(l, runBuf)
+		got := mod.logImputed(runBuf)
+		// Each recorded 3-multiset is contained only in itself among
+		// size-3 leaves, so its containment lift is w_i / wMean.
+		want := math.Log(weights[i] / wMean)
+		if math.Abs(got-want) > 1e-9 {
+			t.Fatalf("leaf %v: logImputed=%v want=%v", l, got, want)
+		}
+	}
+}
+
+// subleaveTerms mirrors the sub-multiset walk of logImputed: its φ terms must
+// sum to logImputed exactly, for leaves with and without repeated tiles.
+func TestSubleaveTermsSumMatchesLogImputed(t *testing.T) {
+	acc := newSubleaveAccumulator(5, 3)
+	leaves := [][]tilemapping.MachineLetter{
+		mls(1, 2, 3),
+		mls(1, 1, 2),
+		mls(1, 1, 1),
+		mls(2, 3, 3),
+		mls(1, 3, 4),
+		mls(2, 2, 4),
+	}
+	weights := []float64{8, 2, 5, 1, 3, 0.25}
+	for i, l := range leaves {
+		acc.record(l, weights[i])
+	}
+	mod := buildImputationModel(acc, imputationLambda, maxAbsLogLift, maxAbsInteraction)
+
+	queries := append(leaves, mls(2, 3, 4), mls(4, 4, 4), mls(1, 2, 2))
+	var runBuf []tileRun
+	for _, l := range queries {
+		runBuf = runsOf(l, runBuf)
+		terms := mod.subleaveTerms(runBuf)
+		sum := 0.0
+		for _, tm := range terms {
+			sum += tm.phi
+		}
+		want := mod.logImputed(runBuf)
+		if math.Abs(sum-want) > 1e-12 {
+			t.Fatalf("leaf %v: Σφ over subleaveTerms=%v, logImputed=%v", l, sum, want)
+		}
+	}
+}
+
+// The pieces persisted on imputationResult (model, logCalib, maxLogW) must
+// reconstruct every posterior weight exactly — this is the formula the
+// AnalyzeLeave walkthrough displays.
+func TestImputationResultReconstructsWeights(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 5, 5, 5, 5}
+	k := 3
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	truth := func(tiles []tilemapping.MachineLetter) float64 {
+		w := 1.0
+		for _, t := range tiles {
+			if t == 1 {
+				w *= 2
+			}
+		}
+		return w
+	}
+	holdout := map[string]bool{
+		leaveKey(mls(1, 2, 3)): true,
+		leaveKey(mls(2, 3, 4)): true,
+	}
+	for _, l := range enumerateLeaves(bagMap, k) {
+		key := leaveKey(l.tiles)
+		if holdout[key] {
+			continue
+		}
+		acc.record(l.tiles, truth(l.tiles))
+		if measured[key] == nil {
+			measured[key] = &measuredLeave{}
+		}
+		measured[key].sumW += truth(l.tiles)
+		measured[key].count++
+	}
+
+	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	is.True(res.model != nil)
+	is.True(len(res.racks) > 0)
+
+	var runBuf []tileRun
+	for _, r := range res.racks {
+		prior := combinatorialPrior(r.Leave, bagMap)
+		var logLik float64
+		if ml := measured[leaveKey(r.Leave)]; ml != nil && ml.count > 0 {
+			logLik = math.Log(ml.mean())
+		} else {
+			runBuf = runsOf(r.Leave, runBuf)
+			logLik = res.logCalib + res.model.logImputed(runBuf)
+		}
+		got := math.Exp(math.Log(prior) + logLik - res.maxLogW)
+		if math.Abs(got-r.Weight) > 1e-9*r.Weight {
+			t.Fatalf("leaf %v: reconstructed %v, stored %v", r.Leave, got, r.Weight)
+		}
+	}
+}
+
+// The calibration constant must moment-match the arithmetic mean of measured
+// likelihoods: Σ c·exp(logCalib + Σφ) = Σ c·w. With heavily skewed
+// likelihoods a mean-of-logs anchor would land orders of magnitude below the
+// arithmetic scale, starving imputed leaves of posterior mass.
+func TestCalibrationMomentMatched(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 5, 5, 5, 5}
+	k := 3
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	// Heavily right-skewed: likelihoods span ~5 orders of magnitude.
+	truth := func(tiles []tilemapping.MachineLetter) float64 {
+		w := 1.0
+		for _, tl := range tiles {
+			w *= math.Pow(10, -float64(tl)+2)
+		}
+		return w
+	}
+	holdout := map[string]bool{
+		leaveKey(mls(1, 2, 3)): true,
+		leaveKey(mls(2, 3, 4)): true,
+	}
+	for _, l := range enumerateLeaves(bagMap, k) {
+		key := leaveKey(l.tiles)
+		if holdout[key] {
+			continue
+		}
+		acc.record(l.tiles, truth(l.tiles))
+		if measured[key] == nil {
+			measured[key] = &measuredLeave{}
+		}
+		measured[key].sumW += truth(l.tiles)
+		measured[key].count++
+	}
+
+	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	is.True(res.model != nil)
+
+	var predicted, actual float64
+	var runBuf []tileRun
+	tiles := make([]tilemapping.MachineLetter, 0, k)
+	for key, ml := range measured {
+		if ml.mean() <= 0 {
+			continue
+		}
+		tiles = tiles[:0]
+		for i := 0; i < len(key); i++ {
+			tiles = append(tiles, tilemapping.MachineLetter(key[i]))
+		}
+		runBuf = runsOf(tiles, runBuf)
+		c := float64(ml.count)
+		predicted += c * math.Exp(res.logCalib+res.model.logImputed(runBuf))
+		actual += c * ml.mean()
+	}
+	if math.Abs(predicted-actual) > 1e-9*actual {
+		t.Fatalf("moment mismatch: predicted Σc·ℓ̂=%v, actual Σc·w=%v", predicted, actual)
+	}
+}
+
+// A fully-measured leave space reproduces exact Bayesian weights:
+// posterior ∝ prior × measured likelihood.
+func TestImputeFullPosteriorMeasuredExact(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 3, 2, 1} // tiles 1,2,3 with counts 3,2,1
+	k := 2
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	leaves := enumerateLeaves(bagMap, k)
+	is.True(len(leaves) > 0)
+	// Assign each leaf a distinct positive likelihood.
+	likelihood := func(tiles []tilemapping.MachineLetter) float64 {
+		s := 0.13
+		for _, t := range tiles {
+			s += float64(t) * 0.71
+		}
+		return s
+	}
+	for _, l := range leaves {
+		w := likelihood(l.tiles)
+		acc.record(l.tiles, w)
+		key := leaveKey(l.tiles)
+		if measured[key] == nil {
+			measured[key] = &measuredLeave{}
+		}
+		measured[key].sumW += w
+		measured[key].count++
+	}
+
+	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	is.Equal(res.measuredLeaves, len(leaves))
+	is.Equal(res.imputedLeaves, 0)
+	is.True(res.measuredMass > 0.999)
+
+	// Cross-check weight ratios against prior × likelihood.
+	want := map[string]float64{}
+	for _, l := range leaves {
+		want[leaveKey(l.tiles)] = l.prior * likelihood(l.tiles)
+	}
+	// Normalize both sides by their max and compare.
+	maxGot, maxWant := 0.0, 0.0
+	for _, r := range res.racks {
+		if r.Weight > maxGot {
+			maxGot = r.Weight
+		}
+	}
+	for _, w := range want {
+		if w > maxWant {
+			maxWant = w
+		}
+	}
+	for _, r := range res.racks {
+		w, ok := want[leaveKey(r.Leave)]
+		is.True(ok)
+		if math.Abs(r.Weight/maxGot-w/maxWant) > 1e-9 {
+			t.Fatalf("leaf %v: got %v want %v", r.Leave, r.Weight/maxGot, w/maxWant)
+		}
+	}
+}
+
+// Unmeasured leaves get likelihoods imputed from marginal lifts: with a
+// multiplicative ground truth (containing tile 1 doubles the likelihood),
+// the imputed ratio between two unmeasured leaves that differ only by
+// tile 1 vs tile 4 should be close to 2.
+func TestImputeUnmeasuredLift(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 5, 5, 5, 5} // tiles 1..4, five copies each
+	k := 3
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	truth := func(tiles []tilemapping.MachineLetter) float64 {
+		w := 1.0
+		for _, t := range tiles {
+			if t == 1 {
+				w *= 2
+			}
+		}
+		return w
+	}
+
+	holdout := map[string]bool{
+		leaveKey(mls(1, 2, 3)): true,
+		leaveKey(mls(2, 3, 4)): true,
+	}
+
+	leaves := enumerateLeaves(bagMap, k)
+	for _, l := range leaves {
+		key := leaveKey(l.tiles)
+		if holdout[key] {
+			continue
+		}
+		// Record repeatedly so shrinkage (λ=10) has little effect.
+		for rep := 0; rep < 30; rep++ {
+			acc.record(l.tiles, truth(l.tiles))
+		}
+		if measured[key] == nil {
+			measured[key] = &measuredLeave{}
+		}
+		measured[key].sumW += truth(l.tiles) * 30
+		measured[key].count += 30
+	}
+
+	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	is.Equal(res.imputedLeaves, 2)
+
+	var w123, w234 float64
+	for _, r := range res.racks {
+		switch leaveKey(r.Leave) {
+		case leaveKey(mls(1, 2, 3)):
+			w123 = r.Weight
+		case leaveKey(mls(2, 3, 4)):
+			w234 = r.Weight
+		}
+	}
+	is.True(w123 > 0)
+	is.True(w234 > 0)
+	// Equal priors (symmetric counts), so the weight ratio is the imputed
+	// likelihood ratio; ground truth is 2.
+	ratio := w123 / w234
+	if ratio < 1.4 || ratio > 2.6 {
+		t.Fatalf("imputed lift ratio %v, want ≈2", ratio)
+	}
+}
+
+// With no recorded signal at all, the model must degrade to the prior.
+func TestImputeNoSignalIsPrior(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 4, 3, 2}
+	k := 2
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	res := imputeFullPosterior(bagMap, k, acc, map[string]*measuredLeave{}, 1)
+
+	leaves := enumerateLeaves(bagMap, k)
+	is.Equal(len(res.racks), len(leaves))
+
+	prior := map[string]float64{}
+	maxPrior := 0.0
+	for _, l := range leaves {
+		prior[leaveKey(l.tiles)] = l.prior
+		if l.prior > maxPrior {
+			maxPrior = l.prior
+		}
+	}
+	for _, r := range res.racks {
+		want := prior[leaveKey(r.Leave)] / maxPrior
+		if math.Abs(r.Weight-want) > 1e-9 {
+			t.Fatalf("leaf %v: got %v want %v (prior)", r.Leave, r.Weight, want)
+		}
+	}
+}
+
+// Zero-likelihood measurements are evidence of impossibility, not missing
+// data: they must be excluded from the posterior rather than imputed.
+func TestMeasuredZeroExcluded(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 2, 2}
+	k := 1
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	acc.record(mls(1), 1.0)
+	measured[leaveKey(mls(1))] = &measuredLeave{sumW: 1.0, count: 1}
+	acc.record(mls(2), 0.0)
+	measured[leaveKey(mls(2))] = &measuredLeave{sumW: 0.0, count: 1}
+
+	res := imputeFullPosterior(bagMap, k, acc, measured, 1)
+	is.Equal(len(res.racks), 1)
+	is.Equal(res.racks[0].Leave[0], tilemapping.MachineLetter(1))
+}
+
+// Worst realistic case: 6-tile leaves from a near-full English bag.
+func BenchmarkImputeFullPosteriorK6(b *testing.B) {
+	// Standard English distribution: blank(0)=2, A=9, B=2, C=2, D=4, E=12,
+	// F=2, G=3, H=2, I=9, J=1, K=1, L=4, M=2, N=6, O=8, P=2, Q=1, R=6, S=4,
+	// T=6, U=4, V=2, W=2, X=1, Y=2, Z=1; minus a played tile and our rack of
+	// 7 is immaterial for the benchmark.
+	bagMap := []uint8{2, 9, 2, 2, 4, 12, 2, 3, 2, 9, 1, 1, 4, 2, 6, 8, 2, 1, 6, 4, 6, 4, 2, 2, 1, 2, 1}
+	k := 6
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	measured := map[string]*measuredLeave{}
+
+	// Simulate ~2000 evaluated samples with a deterministic pseudo-pattern.
+	tiles := make([]tilemapping.MachineLetter, k)
+	seed := uint64(12345)
+	next := func(n int) int {
+		seed = seed*6364136223846793005 + 1442695040888963407
+		return int((seed >> 33) % uint64(n))
+	}
+	for i := 0; i < 2000; i++ {
+		for j := range tiles {
+			tiles[j] = tilemapping.MachineLetter(next(len(bagMap)))
+		}
+		w := 1.0 / float64(1+next(50))
+		l := make([]tilemapping.MachineLetter, k)
+		copy(l, tiles)
+		// record sorts in place.
+		acc0 := l
+		sortMLs(acc0)
+		acc.record(acc0, w)
+		key := leaveKey(acc0)
+		if measured[key] == nil {
+			measured[key] = &measuredLeave{}
+		}
+		measured[key].sumW += w
+		measured[key].count++
+	}
+
+	b.ResetTimer()
+	var leafCount int
+	for i := 0; i < b.N; i++ {
+		res := imputeFullPosterior(bagMap, k, acc, measured, 8)
+		leafCount = len(res.racks)
+	}
+	b.ReportMetric(float64(leafCount), "leaves")
+}
+
+func sortMLs(l []tilemapping.MachineLetter) {
+	for i := 1; i < len(l); i++ {
+		for j := i; j > 0 && l[j-1] > l[j]; j-- {
+			l[j-1], l[j] = l[j], l[j-1]
+		}
+	}
+}

--- a/rangefinder/imputation_test.go
+++ b/rangefinder/imputation_test.go
@@ -285,7 +285,7 @@ func TestImputationResultReconstructsWeights(t *testing.T) {
 		measured[key].sumU++
 	}
 
-	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	res := imputeFullPosterior(bagMap, k, acc, nil, measured, 2)
 	is.True(res.model != nil)
 	is.True(len(res.racks) > 0)
 
@@ -343,7 +343,7 @@ func TestCalibrationMomentMatched(t *testing.T) {
 		measured[key].sumU++
 	}
 
-	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	res := imputeFullPosterior(bagMap, k, acc, nil, measured, 2)
 	is.True(res.model != nil)
 
 	var predicted, actual float64
@@ -367,7 +367,145 @@ func TestCalibrationMomentMatched(t *testing.T) {
 	}
 }
 
+// recordSample mirrors RangeFinder.recordPlacementSample: one sample feeds
+// the full accumulator, its leave's cross-fitting fold, and the measured map.
+func recordSample(acc *subleaveAccumulator, folds []*subleaveAccumulator,
+	measured map[string]*measuredLeave, tiles []tilemapping.MachineLetter, w float64) {
 
+	key := leaveKey(tiles)
+	acc.record(tiles, w, 1)
+	if len(folds) > 0 {
+		folds[foldForKey(key, len(folds))].record(tiles, w, 1)
+	}
+	if measured[key] == nil {
+		measured[key] = &measuredLeave{}
+	}
+	measured[key].sumW += w
+	measured[key].count++
+	measured[key].sumU++
+}
+
+func newFoldAccumulators(alphaSize, maxOrder, n int) []*subleaveAccumulator {
+	folds := make([]*subleaveAccumulator, n)
+	for i := range folds {
+		folds[i] = newSubleaveAccumulator(alphaSize, maxOrder)
+	}
+	return folds
+}
+
+// Cross-fitting requires that the folds partition the samples exactly (so a
+// complement is a subtraction) and that every measurement of the same leave
+// lands in the same fold (so a complement model has never seen the leave it
+// predicts).
+func TestCrossFitFoldPartition(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 4, 4, 4, 4}
+	k := 3
+	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	folds := newFoldAccumulators(len(bagMap), marginalOrder(k), calibrationFolds)
+	measured := map[string]*measuredLeave{}
+
+	for _, l := range enumerateLeaves(bagMap, k) {
+		// Measure each leave three times, so the same-fold invariant has
+		// something to violate.
+		for rep := 0; rep < 3; rep++ {
+			recordSample(acc, folds, measured, l.tiles, 0.5+0.1*float64(rep))
+		}
+	}
+
+	// Partition: fold counts and sums add back up to the full accumulator.
+	sumN, sumW := 0, 0.0
+	for _, f := range folds {
+		sumN += f.n
+		sumW += f.likTotal
+	}
+	is.Equal(sumN, acc.n)
+	is.True(math.Abs(sumW-acc.likTotal) < 1e-9)
+
+	for _, f := range folds {
+		comp := acc.minus(f)
+		is.Equal(comp.n, acc.n-f.n)
+		for i := range comp.wt1 {
+			is.True(math.Abs(comp.wt1[i]-(acc.wt1[i]-f.wt1[i])) < 1e-9)
+			is.True(math.Abs(comp.wtsq1[i]-(acc.wtsq1[i]-f.wtsq1[i])) < 1e-9)
+			is.True(math.Abs(comp.lik1[i]-(acc.lik1[i]-f.lik1[i])) < 1e-9)
+		}
+	}
+
+	// Same leave, same fold: all measurements of one leave go to a single
+	// fold, so its complement model has never seen it.
+	solo := newFoldAccumulators(len(bagMap), marginalOrder(k), calibrationFolds)
+	soloAcc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
+	for rep := 0; rep < 4; rep++ {
+		recordSample(soloAcc, solo, map[string]*measuredLeave{}, mls(1, 2, 3), 0.25)
+	}
+	nonEmpty := 0
+	for _, f := range solo {
+		if f.n > 0 {
+			nonEmpty++
+			is.Equal(f.n, 4)
+		}
+	}
+	is.Equal(nonEmpty, 1)
+}
+
+// The calibration constant is fit on measured leaves but applied to the
+// unmeasured ones, so the predictions in its denominator must be
+// out-of-sample. Fitting it in-sample lets a leave's own measurements set the
+// very lifts that predict it: the denominator is inflated and C comes out too
+// low, starving every imputed leaf of posterior mass.
+//
+// Here tiles 7 and 8 occur only in one heavily-measured, high-likelihood
+// leave. The full-data model explains that leave through lifts it supplied
+// itself; the model fit on the folds excluding it has never seen those tiles
+// and predicts the flat baseline. Cross-fitting must therefore land
+// materially above the in-sample constant.
+func TestCrossFitRemovesSelfFit(t *testing.T) {
+	is := is.New(t)
+	bagMap := []uint8{0, 5, 5, 5, 5, 5, 5, 5, 5}
+	k := 2 // marginal order 1: φ over single tiles only, so this is by hand
+	order := marginalOrder(k)
+
+	accX := newSubleaveAccumulator(len(bagMap), order)
+	folds := newFoldAccumulators(len(bagMap), order, calibrationFolds)
+	measuredX := map[string]*measuredLeave{}
+	accIn := newSubleaveAccumulator(len(bagMap), order)
+	measuredIn := map[string]*measuredLeave{}
+
+	record := func(tiles []tilemapping.MachineLetter, w float64, reps int) {
+		for i := 0; i < reps; i++ {
+			recordSample(accX, folds, measuredX, tiles, w)
+			recordSample(accIn, nil, measuredIn, tiles, w)
+		}
+	}
+	// Baseline: ordinary leaves over tiles 1-6, likelihood 1.
+	for a := 1; a <= 6; a++ {
+		for b := a + 1; b <= 6; b++ {
+			record(mls(a, b), 1.0, 1)
+		}
+	}
+	// The self-fit leave: tiles 7 and 8 appear nowhere else.
+	record(mls(7, 8), 100.0, 40)
+
+	resX := imputeFullPosterior(bagMap, k, accX, folds, measuredX, 2)
+	resIn := imputeFullPosterior(bagMap, k, accIn, nil, measuredIn, 2)
+	is.True(resX.crossFitted)
+	is.True(!resIn.crossFitted)
+	// Identical samples, so the full-data models agree: only C differs.
+	is.True(math.Abs(resX.logCalibInSample-resIn.logCalib) < 1e-12)
+
+	// The full model has learned a lift for tiles 7/8 from that leave alone.
+	runs := runsOf(mls(7, 8), nil)
+	is.True(resX.model.logImputed(runs) > 0.5)
+
+	t.Logf("C: cross-fit %.4f, in-sample %.4f (%.3fx)", resX.logCalib,
+		resX.logCalibInSample, math.Exp(resX.logCalib-resX.logCalibInSample))
+	// Deterministic inputs: the observed gap is 0.407 (1.50x).
+	if resX.logCalib <= resX.logCalibInSample+0.3 {
+		t.Fatalf("cross-fitting failed to undo the self-fit: C %.4f vs in-sample %.4f",
+			resX.logCalib, resX.logCalibInSample)
+	}
+}
 
 // A fully-measured leave space reproduces exact Bayesian weights:
 // posterior ∝ prior × measured likelihood.
@@ -400,7 +538,7 @@ func TestImputeFullPosteriorMeasuredExact(t *testing.T) {
 		measured[key].sumU++
 	}
 
-	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	res := imputeFullPosterior(bagMap, k, acc, nil, measured, 2)
 	is.Equal(res.measuredLeaves, len(leaves))
 	is.Equal(res.imputedLeaves, 0)
 	is.True(res.measuredMass > 0.999)
@@ -474,7 +612,7 @@ func TestImputeUnmeasuredLift(t *testing.T) {
 		measured[key].count += 30
 	}
 
-	res := imputeFullPosterior(bagMap, k, acc, measured, 2)
+	res := imputeFullPosterior(bagMap, k, acc, nil, measured, 2)
 	is.Equal(res.imputedLeaves, 2)
 
 	var w123, w234 float64
@@ -502,7 +640,7 @@ func TestImputeNoSignalIsPrior(t *testing.T) {
 	bagMap := []uint8{0, 4, 3, 2}
 	k := 2
 	acc := newSubleaveAccumulator(len(bagMap), marginalOrder(k))
-	res := imputeFullPosterior(bagMap, k, acc, map[string]*measuredLeave{}, 1)
+	res := imputeFullPosterior(bagMap, k, acc, nil, map[string]*measuredLeave{}, 1)
 
 	leaves := enumerateLeaves(bagMap, k)
 	is.Equal(len(res.racks), len(leaves))
@@ -537,7 +675,7 @@ func TestMeasuredZeroExcluded(t *testing.T) {
 	acc.record(mls(2), 0.0, 1)
 	measured[leaveKey(mls(2))] = &measuredLeave{sumW: 0.0, count: 1}
 
-	res := imputeFullPosterior(bagMap, k, acc, measured, 1)
+	res := imputeFullPosterior(bagMap, k, acc, nil, measured, 1)
 	is.Equal(len(res.racks), 1)
 	is.Equal(res.racks[0].Leave[0], tilemapping.MachineLetter(1))
 }
@@ -583,7 +721,7 @@ func BenchmarkImputeFullPosteriorK6(b *testing.B) {
 	b.ResetTimer()
 	var leafCount int
 	for i := 0; i < b.N; i++ {
-		res := imputeFullPosterior(bagMap, k, acc, measured, 8)
+		res := imputeFullPosterior(bagMap, k, acc, nil, measured, 8)
 		leafCount = len(res.racks)
 	}
 	b.ReportMetric(float64(leafCount), "leaves")

--- a/rangefinder/inference.go
+++ b/rangefinder/inference.go
@@ -238,9 +238,11 @@ type RangeFinder struct {
 	inference            *Inference
 
 	// Imputation state (tile-placement inference only): containment-marginal
-	// accumulator, per-distinct-leave measured likelihood means, and the
+	// accumulator, the same samples partitioned into cross-fitting folds for
+	// calibration, per-distinct-leave measured likelihood means, and the
 	// diagnostics of the last imputation run.
 	acc       *subleaveAccumulator
+	foldAccs  []*subleaveAccumulator
 	measured  map[string]*measuredLeave
 	imputeRes *imputationResult
 
@@ -458,9 +460,23 @@ func (r *RangeFinder) PrepareFinder(myRack []tilemapping.MachineLetter) error {
 	r.simCount.Store(0)
 	r.exhaustiveTotal = 0
 	r.acc = nil
+	r.foldAccs = nil
 	r.measured = nil
 	r.imputeRes = nil
 	return nil
+}
+
+// initImputationState (re)allocates the containment-marginal accumulator, the
+// per-fold accumulators used to cross-fit the calibration constant, and the
+// measured-leave map.
+func (r *RangeFinder) initImputationState() {
+	order := marginalOrder(r.inference.RackLength)
+	r.acc = newSubleaveAccumulator(len(r.inferenceBagMap), order)
+	r.foldAccs = make([]*subleaveAccumulator, calibrationFolds)
+	for i := range r.foldAccs {
+		r.foldAccs[i] = newSubleaveAccumulator(len(r.inferenceBagMap), order)
+	}
+	r.measured = map[string]*measuredLeave{}
 }
 
 // recordPlacementSample records one evaluated leave and its measured
@@ -475,6 +491,11 @@ func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w
 		b[i] = byte(ml)
 	}
 	key := string(b)
+	if n := len(r.foldAccs); n > 0 {
+		// Keyed by leave, not by sample, so every draw of a leave lands in
+		// the same fold and the complement model has never seen it.
+		r.foldAccs[foldForKey(key, n)].record(leave, w, u)
+	}
 	ml := r.measured[key]
 	if ml == nil {
 		ml = &measuredLeave{}
@@ -495,7 +516,7 @@ func (r *RangeFinder) finalizePlacementPosterior() {
 		return
 	}
 	res := imputeFullPosterior(r.inferenceBagMap, r.inference.RackLength, r.acc,
-		r.measured, r.threads)
+		r.foldAccs, r.measured, r.threads)
 	r.imputeRes = res
 	if len(res.racks) == 0 {
 		return
@@ -506,6 +527,8 @@ func (r *RangeFinder) finalizePlacementPosterior() {
 		Int("imputed-leaves", res.imputedLeaves).
 		Float64("measured-mass", res.measuredMass).
 		Int("marginal-order", res.marginalOrder).
+		Float64("log-calib", res.logCalib).
+		Float64("log-calib-in-sample", res.logCalibInSample).
 		Msg("imputed-complete-posterior")
 }
 
@@ -545,8 +568,7 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 		// Monte Carlo sampling path for tile placements: every sampled leave
 		// (whatever its likelihood) feeds the marginal-lift accumulator so a
 		// complete posterior can be imputed after sampling ends.
-		r.acc = newSubleaveAccumulator(len(r.inferenceBagMap), marginalOrder(r.inference.RackLength))
-		r.measured = map[string]*measuredLeave{}
+		r.initImputationState()
 	}
 
 	logChan := make(chan []byte)

--- a/rangefinder/inference.go
+++ b/rangefinder/inference.go
@@ -465,10 +465,11 @@ func (r *RangeFinder) PrepareFinder(myRack []tilemapping.MachineLetter) error {
 
 // recordPlacementSample records one evaluated leave and its measured
 // likelihood into the imputation accumulator and the per-distinct-leave
-// means. The caller must synchronize; leave is sorted in place.
-func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w float64) {
+// means. u is the draw's importance weight P(L)/q(L); prior-sampled draws
+// pass 1. The caller must synchronize; leave is sorted in place.
+func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w, u float64) {
 	sort.Slice(leave, func(i, j int) bool { return leave[i] < leave[j] })
-	r.acc.record(leave, w)
+	r.acc.record(leave, w, u)
 	b := make([]byte, len(leave))
 	for i, ml := range leave {
 		b[i] = byte(ml)
@@ -481,6 +482,7 @@ func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w
 	}
 	ml.sumW += w
 	ml.count++
+	ml.sumU += u
 }
 
 // finalizePlacementPosterior turns the recorded samples into a complete
@@ -492,7 +494,8 @@ func (r *RangeFinder) finalizePlacementPosterior() {
 	if r.acc == nil || r.acc.n == 0 {
 		return
 	}
-	res := imputeFullPosterior(r.inferenceBagMap, r.inference.RackLength, r.acc, r.measured, r.threads)
+	res := imputeFullPosterior(r.inferenceBagMap, r.inference.RackLength, r.acc,
+		r.measured, r.threads)
 	r.imputeRes = res
 	if len(res.racks) == 0 {
 		return
@@ -613,7 +616,8 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 						// Tile-placement path: Weight carries the measured
 						// likelihood; accumulate for imputation.
 						for _, ir := range newRacks {
-							r.recordPlacementSample(ir.Leave, ir.Weight)
+							// Round 0 draws from the prior, so u = 1.
+							r.recordPlacementSample(ir.Leave, ir.Weight, 1)
 						}
 					} else {
 						// Exchange path: keep distinct racks, first weight wins.

--- a/rangefinder/inference.go
+++ b/rangefinder/inference.go
@@ -246,6 +246,17 @@ type RangeFinder struct {
 	measured  map[string]*measuredLeave
 	imputeRes *imputationResult
 
+	// Refinement state: how many rounds of posterior-guided measurement to
+	// run after round 0 (0 disables it), how many leaves they measured, and
+	// the per-round convergence statistics.
+	maxRounds     int
+	refinedCount  int
+	roundLog      []roundStats
+	stage0Elapsed time.Duration
+	// currentRound stamps newly measured leaves with the round that measured
+	// them. Written only by refineRounds, between batches.
+	currentRound int
+
 	logStream io.Writer
 }
 
@@ -256,6 +267,7 @@ func (r *RangeFinder) Init(game *game.Game, eqCalcs []equity.EquityCalculator,
 	r.equityCalculators = eqCalcs
 	r.threads = max(1, runtime.NumCPU())
 	r.cfg = cfg
+	r.maxRounds = DefaultMaxRefineRounds
 }
 
 func (r *RangeFinder) SetThreads(t int) {
@@ -275,6 +287,15 @@ func (r *RangeFinder) Tau() float64 {
 	}
 	return r.tau
 }
+
+// SetMaxRounds sets how many measure–impute–recalibrate rounds run after the
+// prior-sampled round 0. 0 disables refinement, leaving single-stage
+// inference. Init seeds it with DefaultMaxRefineRounds.
+func (r *RangeFinder) SetMaxRounds(n int) {
+	r.maxRounds = max(0, n)
+}
+
+func (r *RangeFinder) MaxRounds() int { return max(0, r.maxRounds) }
 
 func (r *RangeFinder) SetSimIters(n int) {
 	r.simIters = n
@@ -463,6 +484,9 @@ func (r *RangeFinder) PrepareFinder(myRack []tilemapping.MachineLetter) error {
 	r.foldAccs = nil
 	r.measured = nil
 	r.imputeRes = nil
+	r.refinedCount = 0
+	r.roundLog = nil
+	r.stage0Elapsed = 0
 	return nil
 }
 
@@ -498,7 +522,7 @@ func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w
 	}
 	ml := r.measured[key]
 	if ml == nil {
-		ml = &measuredLeave{}
+		ml = &measuredLeave{round: r.currentRound}
 		r.measured[key] = ml
 	}
 	ml.sumW += w
@@ -577,6 +601,24 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 
 	ctrl := errgroup.Group{}
 	writer := errgroup.Group{}
+
+	// Round 0 is blind, prior-sampled exploration. When refinement rounds
+	// will follow, it only gets refineStage0Frac of the budget; the rest pays
+	// for posterior-guided measurement.
+	parentCtx := ctx
+	rounds := 0
+	if r.acc != nil {
+		rounds = r.MaxRounds()
+	}
+	if rounds > 0 {
+		if deadline, ok := parentCtx.Deadline(); ok {
+			stage0End := time.Now().Add(
+				time.Duration(float64(time.Until(deadline)) * refineStage0Frac))
+			var cancelStage0 context.CancelFunc
+			ctx, cancelStage0 = context.WithDeadline(parentCtx, stage0End)
+			defer cancelStage0()
+		}
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -675,10 +717,15 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 	ctrlErr := ctrl.Wait()
 	log.Debug().Msgf("ctrl errgroup returned err %v", ctrlErr)
 
-	// Sampling has ended (typically by deadline); build the complete
-	// posterior from what was measured. CPU-bound and fast, so it runs
-	// even though ctx is already done.
+	// Round 0 has ended (typically by deadline); build the complete posterior
+	// from what was measured. CPU-bound and fast, so it runs even though ctx
+	// is already done.
+	r.stage0Elapsed = time.Since(inferStart)
 	r.finalizePlacementPosterior()
+
+	// Then alternate measurement and imputation on the remaining budget,
+	// drawing leaves from the posterior the model just produced.
+	r.refineRounds(parentCtx, rounds)
 
 	if ctrlErr == context.Canceled || ctrlErr == context.DeadlineExceeded {
 		// Not actually an error

--- a/rangefinder/inference.go
+++ b/rangefinder/inference.go
@@ -65,7 +65,13 @@ type LogIteration struct {
 type Inference struct {
 	RackLength    int
 	InferredRacks []montecarlo.InferredRack
-	seen          map[string]int // leaveKey -> index in InferredRacks
+	// Complete is true when InferredRacks covers every feasible leave — a
+	// full posterior the simmer can sample from directly, with no random
+	// fallback. Tile-placement inference always produces a complete
+	// posterior (measured leaves use their evaluated likelihood, the rest
+	// are imputed from marginal lifts); exchange inference does not.
+	Complete bool
+	seen     map[string]int // leaveKey -> index in InferredRacks (exchange path)
 }
 
 func NewInference() *Inference {
@@ -230,6 +236,13 @@ type RangeFinder struct {
 	// tiles used by the last opponent's move, from their rack:
 	lastOppMoveRackTiles []tilemapping.MachineLetter
 	inference            *Inference
+
+	// Imputation state (tile-placement inference only): containment-marginal
+	// accumulator, per-distinct-leave measured likelihood means, and the
+	// diagnostics of the last imputation run.
+	acc       *subleaveAccumulator
+	measured  map[string]*measuredLeave
+	imputeRes *imputationResult
 
 	logStream io.Writer
 }
@@ -444,7 +457,53 @@ func (r *RangeFinder) PrepareFinder(myRack []tilemapping.MachineLetter) error {
 	r.iterationCount = 0
 	r.simCount.Store(0)
 	r.exhaustiveTotal = 0
+	r.acc = nil
+	r.measured = nil
+	r.imputeRes = nil
 	return nil
+}
+
+// recordPlacementSample records one evaluated leave and its measured
+// likelihood into the imputation accumulator and the per-distinct-leave
+// means. The caller must synchronize; leave is sorted in place.
+func (r *RangeFinder) recordPlacementSample(leave []tilemapping.MachineLetter, w float64) {
+	sort.Slice(leave, func(i, j int) bool { return leave[i] < leave[j] })
+	r.acc.record(leave, w)
+	b := make([]byte, len(leave))
+	for i, ml := range leave {
+		b[i] = byte(ml)
+	}
+	key := string(b)
+	ml := r.measured[key]
+	if ml == nil {
+		ml = &measuredLeave{}
+		r.measured[key] = ml
+	}
+	ml.sumW += w
+	ml.count++
+}
+
+// finalizePlacementPosterior turns the recorded samples into a complete
+// posterior over every feasible leave: measured leaves keep their evaluated
+// mean likelihood, unmeasured ones get a likelihood imputed from marginal
+// lifts. No-op if nothing was recorded (Complete stays false and the simmer
+// falls back to random racks).
+func (r *RangeFinder) finalizePlacementPosterior() {
+	if r.acc == nil || r.acc.n == 0 {
+		return
+	}
+	res := imputeFullPosterior(r.inferenceBagMap, r.inference.RackLength, r.acc, r.measured, r.threads)
+	r.imputeRes = res
+	if len(res.racks) == 0 {
+		return
+	}
+	r.inference.InferredRacks = res.racks
+	r.inference.Complete = true
+	log.Info().Int("measured-leaves", res.measuredLeaves).
+		Int("imputed-leaves", res.imputedLeaves).
+		Float64("measured-mass", res.measuredMass).
+		Int("marginal-order", res.marginalOrder).
+		Msg("imputed-complete-posterior")
 }
 
 func (r *RangeFinder) Infer(ctx context.Context) error {
@@ -477,6 +536,14 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 		}
 		log.Info().Int("leaf-count", m).Int("max-leaves", maxLeaves).
 			Msg("leaf-space-too-large-using-sampling")
+	}
+
+	if !isExchange && r.inference.RackLength >= 1 {
+		// Monte Carlo sampling path for tile placements: every sampled leave
+		// (whatever its likelihood) feeds the marginal-lift accumulator so a
+		// complete posterior can be imputed after sampling ends.
+		r.acc = newSubleaveAccumulator(len(r.inferenceBagMap), marginalOrder(r.inference.RackLength))
+		r.measured = map[string]*measuredLeave{}
 	}
 
 	logChan := make(chan []byte)
@@ -542,11 +609,20 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 				}
 				if len(newRacks) > 0 {
 					iterMutex.Lock()
-					for _, ir := range newRacks {
-						key := leaveKey(ir.Leave)
-						if _, exists := r.inference.seen[key]; !exists {
-							r.inference.InferredRacks = append(r.inference.InferredRacks, ir)
-							r.inference.seen[key] = len(r.inference.InferredRacks) - 1
+					if r.acc != nil {
+						// Tile-placement path: Weight carries the measured
+						// likelihood; accumulate for imputation.
+						for _, ir := range newRacks {
+							r.recordPlacementSample(ir.Leave, ir.Weight)
+						}
+					} else {
+						// Exchange path: keep distinct racks, first weight wins.
+						for _, ir := range newRacks {
+							key := leaveKey(ir.Leave)
+							if _, exists := r.inference.seen[key]; !exists {
+								r.inference.InferredRacks = append(r.inference.InferredRacks, ir)
+								r.inference.seen[key] = len(r.inference.InferredRacks) - 1
+							}
 						}
 					}
 					iterMutex.Unlock()
@@ -572,6 +648,11 @@ func (r *RangeFinder) Infer(ctx context.Context) error {
 
 	ctrlErr := ctrl.Wait()
 	log.Debug().Msgf("ctrl errgroup returned err %v", ctrlErr)
+
+	// Sampling has ended (typically by deadline); build the complete
+	// posterior from what was measured. CPU-bound and fast, so it runs
+	// even though ctx is already done.
+	r.finalizePlacementPosterior()
 
 	if ctrlErr == context.Canceled || ctrlErr == context.DeadlineExceeded {
 		// Not actually an error
@@ -625,15 +706,12 @@ func (r *RangeFinder) inferSingle(thread, iterNum int, logChan chan []byte) ([]m
 		logIter.SimLogFile = logfilename
 	}
 
-	// SetRandomRack already samples racks from the hypergeometric (prior)
-	// distribution, so the IS weight is only the likelihood P(play | leave).
-	// Multiplying by the prior again would double-count it.
+	// The returned Weight is the measured likelihood P(play | leave); the
+	// prior enters later, when the full posterior is assembled (measured
+	// leaves get prior × mean measured likelihood). Zero-likelihood samples
+	// are returned too: they still count toward the containment-marginal
+	// denominators used for imputation.
 	likelihoodP, targetWinProb := softmaxLikelihood(bestPlays, lastOppMove, g.Board(), r.Tau())
-	bayesianWeight := likelihoodP
-
-	if bayesianWeight <= 0 {
-		return nil, nil
-	}
 
 	tiles := make([]tilemapping.MachineLetter, len(extraDrawn))
 	copy(tiles, extraDrawn)
@@ -649,7 +727,7 @@ func (r *RangeFinder) inferSingle(thread, iterNum int, logChan chan []byte) ([]m
 		logChan <- out
 	}
 
-	return []montecarlo.InferredRack{{Leave: tiles, Weight: bayesianWeight}}, nil
+	return []montecarlo.InferredRack{{Leave: tiles, Weight: likelihoodP}}, nil
 }
 
 func (r *RangeFinder) inferSingleExchange(thread, iterNum int, logChan chan []byte) ([]montecarlo.InferredRack, error) {

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -108,6 +108,8 @@ func TestInferTilePlay(t *testing.T) {
 		fmt.Println(measuredAnalysis)
 		is.True(strings.Contains(measuredAnalysis, "measured: evaluated"))
 		is.True(strings.Contains(measuredAnalysis, "weight = prior × mean likelihood ÷ max"))
+		is.True(strings.Contains(measuredAnalysis, "imputation model comparison"))
+		is.True(strings.Contains(measuredAnalysis, "measured/imputed likelihood ratio"))
 	}
 	if imputedStr != "" {
 		imputedAnalysis, err := rangeFinder.AnalyzeLeave(imputedStr)

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -58,11 +58,11 @@ func TestInferTilePlay(t *testing.T) {
 
 	rangeFinder := &RangeFinder{}
 	rangeFinder.Init(game, calcs, DefaultConfig)
-	// Short mini-sims: this exercises the inference pipeline, not simulation
-	// accuracy, and at the default 200 iterations a few seconds of budget on
-	// a loaded machine buys only a handful of evaluated leaves — too few for
-	// the refinement rounds below to have anything to work with.
-	rangeFinder.SetSimIters(25)
+	// Single-stage: this test covers the posterior and its displays, and
+	// giving round 0 the whole budget keeps what it sees independent of how
+	// many refinement rounds happened to fit. TestInferRefinementRounds
+	// covers the loop.
+	rangeFinder.SetMaxRounds(0)
 
 	f, err := os.Create("/tmp/inferlog")
 	is.NoErr(err)
@@ -85,27 +85,11 @@ func TestInferTilePlay(t *testing.T) {
 	// Query a specific leave from the complete posterior.
 	is.True(rangeFinder.inference.Complete)
 
-	// The refine loop must have run: leaves drawn from the imputed posterior
-	// and evaluated for real, each round reporting how far the model's
-	// imputed weights were from those evaluations.
-	is.True(rangeFinder.refinedCount > 0)
-	is.True(len(rangeFinder.roundLog) > 0)
-	for _, st := range rangeFinder.roundLog {
-		is.True(st.drawn > 0)
-		is.True(st.evaluated > 0)
-		is.True(st.distinct <= st.drawn)
-		is.True(st.seLogRatio >= 0)
-		is.True(!math.IsNaN(st.logRatio))
-		is.True(!math.IsNaN(st.seLogRatio))
-		// A batch too small to have a meaningful interval must never be
-		// allowed to declare convergence: with one leaf the ratio fits
-		// exactly and the standard error is 0.
-		if st.converged {
-			is.True(st.evaluated >= refineMinBatch)
-		}
-	}
-	// Refined leaves are measured, so they carry exact weights.
-	is.True(rangeFinder.imputeRes.measuredLeaves >= rangeFinder.refinedCount)
+	// SetMaxRounds(0) means exactly that: everything measured here came from
+	// round 0's prior sampling.
+	is.Equal(rangeFinder.refinedCount, 0)
+	is.Equal(len(rangeFinder.roundLog), 0)
+
 	top := rangeFinder.inference.InferredRacks[0]
 	topStr := tilemapping.MachineWord(top.Leave).UserVisible(game.Alphabet())
 	analysis, err := rangeFinder.AnalyzeLeave(topStr)
@@ -158,6 +142,104 @@ func TestInferTilePlay(t *testing.T) {
 	// Wrong leave length errors out.
 	_, err = rangeFinder.AnalyzeLeave("A")
 	is.True(err != nil)
+}
+
+// TestInferRefinementRounds covers the measure–impute–recalibrate loop
+// end-to-end: leaves drawn from the imputed posterior, evaluated with real
+// mini-sims, and folded back in as exact weights.
+//
+// The leave space has to be large for the assertions to be deterministic. In
+// a small one, round 0 alone can measure nearly everything worth measuring,
+// and refinement then correctly does nothing — it stops on "unmeasured mass
+// below the floor" or finds no candidates left at all, and refinedCount is
+// legitimately 0. Four tiles played out of a full bag leaves thousands of
+// candidates, so there is always something for the loop to draw.
+func TestInferRefinementRounds(t *testing.T) {
+	is := is.New(t)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	lex := "NWL23"
+	players := []*macondo.PlayerInfo{
+		{Nickname: "p1", RealName: "Alice"},
+		{Nickname: "p2", RealName: "Bob"},
+	}
+	rules, err := game.NewBasicGameRules(DefaultConfig, lex, board.CrosswordGameLayout,
+		"English", game.CrossScoreAndSet, game.VarClassic)
+	is.NoErr(err)
+	g, err := game.NewGame(rules, players)
+	is.NoErr(err)
+	g.StartGame()
+	g.SetPlayerOnTurn(0)
+	g.SetRackFor(0, tilemapping.RackFromString("HELPXYZ", g.Alphabet()))
+	_, err = g.PlayScoringMove("H8", "HELP", true)
+	is.NoErr(err)
+
+	rf := &RangeFinder{}
+	rf.Init(g, defaultSimCalculators(lex), DefaultConfig)
+	is.NoErr(rf.PrepareFinder(nil))
+	is.Equal(rf.inference.RackLength, 3)
+	is.True(countMultisets(rf.inferenceBagMap, rf.inference.RackLength) > 1000)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	is.NoErr(rf.Infer(ctx))
+	fmt.Println(rf.AnalyzeInferences(false))
+
+	is.True(rf.inference.Complete)
+	is.True(rf.refinedCount > 0)
+	is.True(len(rf.roundLog) > 0)
+
+	for _, st := range rf.roundLog {
+		is.True(st.drawn > 0)
+		is.True(st.evaluated > 0)
+		is.True(st.distinct <= st.drawn) // repeats fold into the weight
+		is.True(st.seLogRatio >= 0)
+		is.True(!math.IsNaN(st.logRatio))
+		is.True(!math.IsNaN(st.seLogRatio))
+		is.True(st.unmeasured >= 0 && st.unmeasured <= 1)
+		// A batch too small to have a meaningful interval must never declare
+		// convergence: with one leaf the ratio fits exactly, leaving a zero
+		// residual and a zero standard error.
+		if st.converged {
+			is.True(st.evaluated >= refineMinBatch)
+		}
+	}
+
+	// Refinement only ever draws leaves that are still unmeasured, so every
+	// evaluation it makes lands on a distinct leave stamped with its round.
+	refined := 0
+	for _, ml := range rf.measured {
+		if ml.round > 0 {
+			is.True(ml.count > 0)
+			is.True(ml.sumU > 0)
+			refined++
+		}
+	}
+	is.Equal(refined, rf.refinedCount)
+
+	// A refined leave carries the model's pre-measurement prediction, which
+	// is the only out-of-sample estimate for it that survives the refit.
+	predicted := 0
+	for _, ml := range rf.measured {
+		if ml.round > 0 && ml.predicted > 0 {
+			predicted++
+		}
+	}
+	is.True(predicted > 0)
+
+	// Those leaves carry exact weights in the posterior, and the display says
+	// which round found them. Not every refined leave has a row: one measured
+	// to be impossible is excluded outright, and one whose weight lands under
+	// the negligible-mass cutoff is dropped, so this is a subset.
+	rows := rf.rankedRacks()
+	tagged := 0
+	for _, row := range rows {
+		if row.measured && row.round > 0 {
+			is.True(strings.Contains(row.source(), roundLabel(row.round)))
+			tagged++
+		}
+	}
+	is.True(tagged > 0)
+	is.True(tagged <= rf.refinedCount)
 }
 
 func TestInferExchange(t *testing.T) {

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -106,6 +106,7 @@ func TestInferTilePlay(t *testing.T) {
 		measuredAnalysis, err := rangeFinder.AnalyzeLeave(measuredStr)
 		is.NoErr(err)
 		fmt.Println(measuredAnalysis)
+		is.True(strings.Contains(measuredAnalysis, "[MEASURED ×"))
 		is.True(strings.Contains(measuredAnalysis, "measured: evaluated"))
 		is.True(strings.Contains(measuredAnalysis, "weight = prior × mean likelihood ÷ max"))
 		is.True(strings.Contains(measuredAnalysis, "imputation model comparison"))
@@ -115,7 +116,7 @@ func TestInferTilePlay(t *testing.T) {
 		imputedAnalysis, err := rangeFinder.AnalyzeLeave(imputedStr)
 		is.NoErr(err)
 		fmt.Println(imputedAnalysis)
-		is.True(strings.Contains(imputedAnalysis, "imputed"))
+		is.True(strings.Contains(imputedAnalysis, "[IMPUTED]"))
 		is.True(strings.Contains(imputedAnalysis, "Σφ"))
 		is.True(strings.Contains(imputedAnalysis, "weight = prior × ℓ̂ ÷ max"))
 	}

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -58,6 +58,11 @@ func TestInferTilePlay(t *testing.T) {
 
 	rangeFinder := &RangeFinder{}
 	rangeFinder.Init(game, calcs, DefaultConfig)
+	// Short mini-sims: this exercises the inference pipeline, not simulation
+	// accuracy, and at the default 200 iterations a few seconds of budget on
+	// a loaded machine buys only a handful of evaluated leaves — too few for
+	// the refinement rounds below to have anything to work with.
+	rangeFinder.SetSimIters(25)
 
 	f, err := os.Create("/tmp/inferlog")
 	is.NoErr(err)
@@ -66,7 +71,7 @@ func TestInferTilePlay(t *testing.T) {
 
 	rangeFinder.PrepareFinder(nil)
 	timeout, cancel := context.WithTimeout(
-		context.Background(), 5*time.Second)
+		context.Background(), 10*time.Second)
 	defer cancel()
 
 	err = rangeFinder.Infer(timeout)
@@ -89,8 +94,15 @@ func TestInferTilePlay(t *testing.T) {
 		is.True(st.drawn > 0)
 		is.True(st.evaluated > 0)
 		is.True(st.distinct <= st.drawn)
-		is.True(st.seLogRatio > 0)
+		is.True(st.seLogRatio >= 0)
 		is.True(!math.IsNaN(st.logRatio))
+		is.True(!math.IsNaN(st.seLogRatio))
+		// A batch too small to have a meaningful interval must never be
+		// allowed to declare convergence: with one leaf the ratio fits
+		// exactly and the standard error is 0.
+		if st.converged {
+			is.True(st.evaluated >= refineMinBatch)
+		}
 	}
 	// Refined leaves are measured, so they carry exact weights.
 	is.True(rangeFinder.imputeRes.measuredLeaves >= rangeFinder.refinedCount)

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -3,6 +3,7 @@ package rangefinder
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -78,6 +79,21 @@ func TestInferTilePlay(t *testing.T) {
 
 	// Query a specific leave from the complete posterior.
 	is.True(rangeFinder.inference.Complete)
+
+	// The refine loop must have run: leaves drawn from the imputed posterior
+	// and evaluated for real, each round reporting how far the model's
+	// imputed weights were from those evaluations.
+	is.True(rangeFinder.refinedCount > 0)
+	is.True(len(rangeFinder.roundLog) > 0)
+	for _, st := range rangeFinder.roundLog {
+		is.True(st.drawn > 0)
+		is.True(st.evaluated > 0)
+		is.True(st.distinct <= st.drawn)
+		is.True(st.seLogRatio > 0)
+		is.True(!math.IsNaN(st.logRatio))
+	}
+	// Refined leaves are measured, so they carry exact weights.
+	is.True(rangeFinder.imputeRes.measuredLeaves >= rangeFinder.refinedCount)
 	top := rangeFinder.inference.InferredRacks[0]
 	topStr := tilemapping.MachineWord(top.Leave).UserVisible(game.Alphabet())
 	analysis, err := rangeFinder.AnalyzeLeave(topStr)

--- a/rangefinder/inference_test.go
+++ b/rangefinder/inference_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +75,58 @@ func TestInferTilePlay(t *testing.T) {
 	fmt.Println("analyze inferences")
 	fmt.Println(rangeFinder.AnalyzeInferences(true))
 	fmt.Println(rangeFinder.AnalyzeInferences(false))
+
+	// Query a specific leave from the complete posterior.
+	is.True(rangeFinder.inference.Complete)
+	top := rangeFinder.inference.InferredRacks[0]
+	topStr := tilemapping.MachineWord(top.Leave).UserVisible(game.Alphabet())
+	analysis, err := rangeFinder.AnalyzeLeave(topStr)
+	is.NoErr(err)
+	fmt.Println(analysis)
+	is.True(strings.Contains(analysis, "posterior"))
+
+	// An imputed leave gets the full calculation walkthrough: per-subleave φ
+	// table plus the chain from prior and ℓ̂ to the normalized weight. A
+	// measured leave gets its own prior × mean likelihood chain.
+	var imputedStr, measuredStr string
+	for _, ir := range rangeFinder.inference.InferredRacks {
+		str := tilemapping.MachineWord(ir.Leave).UserVisible(game.Alphabet())
+		if ml := rangeFinder.measured[leaveKey(ir.Leave)]; ml == nil || ml.count == 0 {
+			if imputedStr == "" {
+				imputedStr = str
+			}
+		} else if measuredStr == "" {
+			measuredStr = str
+		}
+		if imputedStr != "" && measuredStr != "" {
+			break
+		}
+	}
+	if measuredStr != "" {
+		measuredAnalysis, err := rangeFinder.AnalyzeLeave(measuredStr)
+		is.NoErr(err)
+		fmt.Println(measuredAnalysis)
+		is.True(strings.Contains(measuredAnalysis, "measured: evaluated"))
+		is.True(strings.Contains(measuredAnalysis, "weight = prior × mean likelihood ÷ max"))
+	}
+	if imputedStr != "" {
+		imputedAnalysis, err := rangeFinder.AnalyzeLeave(imputedStr)
+		is.NoErr(err)
+		fmt.Println(imputedAnalysis)
+		is.True(strings.Contains(imputedAnalysis, "imputed"))
+		is.True(strings.Contains(imputedAnalysis, "Σφ"))
+		is.True(strings.Contains(imputedAnalysis, "weight = prior × ℓ̂ ÷ max"))
+	}
+
+	// Lowercase input is treated as regular (capitalized) tiles, not as
+	// blank designations — `infer leave zit` used to panic.
+	lower, err := rangeFinder.AnalyzeLeave(strings.ToLower(topStr))
+	is.NoErr(err)
+	is.Equal(lower, analysis)
+
+	// Wrong leave length errors out.
+	_, err = rangeFinder.AnalyzeLeave("A")
+	is.True(err != nil)
 }
 
 func TestInferExchange(t *testing.T) {

--- a/rangefinder/refine.go
+++ b/rangefinder/refine.go
@@ -1,0 +1,454 @@
+package rangefinder
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/domino14/word-golib/tilemapping"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/domino14/macondo/ai/simplesimmer"
+	"github.com/domino14/macondo/move"
+)
+
+// This file implements the measure–impute–recalibrate loop described in
+// docs/development/iterative_inference_plan.md. Round 0 (the prior-sampled MC
+// pass in inference.go, or exhaustive enumeration) leaves us with a model
+// fitted to whatever it happened to see. Each refine round then draws leaves
+// from the *current* posterior — biased toward high weight, with a bonus for
+// leaves the model is unsure about — evaluates them for real, and refits. The
+// draws carry importance weights u = P/q so the lift estimator stays unbiased
+// under a proposal that is nothing like the prior.
+
+const (
+	// DefaultMaxRefineRounds bounds the loop regardless of convergence.
+	DefaultMaxRefineRounds = 6
+
+	// refineExplorationLambda scales the uncertainty bonus in the proposal:
+	// q ∝ W · (1 + λ·unc). 0 is pure exploitation.
+	refineExplorationLambda = 1.0
+
+	// refineStage0Frac is the share of the time budget spent on round 0
+	// (blind, prior-sampled exploration) before refinement starts.
+	refineStage0Frac = 0.4
+
+	// refineConvergedTol is the scale error we are willing to live with in the
+	// imputed set: the loop stops once the whole confidence interval of
+	// log R̂ fits inside ±this. 10% is far below the model's shape error.
+	refineConvergedTol = 0.10
+
+	// refineMassCovered stops the loop once the unmeasured leaves hold less
+	// than this share of posterior mass — whatever the model still gets wrong
+	// there cannot move the posterior much.
+	refineMassCovered = 0.02
+
+	// refineMinBatch is the smallest worthwhile round; below this the ratio
+	// statistic is too noisy to learn from.
+	refineMinBatch = 16
+)
+
+// evaluateLeaves runs the mini-sim likelihood measurement for each leave in
+// parallel over the worker threads, calling onResult for each. onResult may be
+// called from any goroutine; callers synchronize. Returns early (without
+// error) when ctx is done, so partial batches are usable.
+func (r *RangeFinder) evaluateLeaves(ctx context.Context, leaves [][]tilemapping.MachineLetter,
+	onResult func(leave []tilemapping.MachineLetter, likelihood float64)) error {
+
+	if len(leaves) == 0 {
+		return nil
+	}
+	var nextIdx atomic.Int64
+	eg := errgroup.Group{}
+	for t := 0; t < r.threads; t++ {
+		t := t
+		eg.Go(func() error {
+			gc := r.gameCopies[t]
+			opp := gc.PlayerOnTurn()
+			simmer := r.aiplayers[t].(*simplesimmer.SimpleSimmer)
+
+			// fullRack is reused across iterations to avoid per-leaf allocation.
+			fullRack := make([]tilemapping.MachineLetter,
+				len(r.lastOppMoveRackTiles)+r.inference.RackLength)
+			copy(fullRack, r.lastOppMoveRackTiles)
+
+			for {
+				i := int(nextIdx.Add(1)) - 1
+				if i >= len(leaves) {
+					return nil
+				}
+				if ctx.Err() != nil {
+					return nil
+				}
+				leave := leaves[i]
+
+				// Build the full deterministic rack: played tiles + this leave.
+				// Passing a full RackTileLimit-length knownRack to SetRandomRack
+				// causes it to: (1) put back the old rack, (2) remove fullRack
+				// from the bag, (3) draw 0 additional tiles — an exact,
+				// deterministic rack assignment.
+				copy(fullRack[len(r.lastOppMoveRackTiles):], leave)
+				if _, err := gc.SetRandomRack(opp, fullRack); err != nil {
+					return err
+				}
+
+				lastOppMove := &move.Move{}
+				lastOppMove.CopyFrom(r.lastOppMove)
+				lastOppMove.SetLeave(leave)
+
+				if _, err := simmer.GenAndSim(context.Background(), 10, lastOppMove); err != nil {
+					return err
+				}
+				r.simCount.Add(1)
+
+				bestPlays := simmer.BestPlays().PlaysNoLock()
+				// Zero-likelihood leaves are reported too — they are measured
+				// evidence, not missing data, so they must not be imputed.
+				likelihood, _ := softmaxLikelihood(bestPlays, lastOppMove, gc.Board(), r.Tau())
+				onResult(leave, likelihood)
+			}
+		})
+	}
+	return eg.Wait()
+}
+
+// refineCandidate is one unmeasured leave with everything the sampler needs.
+type refineCandidate struct {
+	tiles  []tilemapping.MachineLetter
+	weight float64 // current posterior weight (normalized by the max)
+	q      float64 // proposal probability, normalized over the candidates
+	u      float64 // importance weight P/q
+	lhat   float64 // the model's current imputed likelihood, for the ratio test
+}
+
+// buildProposal forms the round's sampling distribution over leaves that have
+// not been measured yet:
+//
+//	q(L) ∝ W(L) · (1 + λ·unc(L))
+//
+// exploiting posterior weight while spending extra draws where the model's own
+// terms rest on thin support. Returns the candidates with normalized q and
+// importance weights u = P/q, plus the share of total posterior mass sitting
+// on unmeasured leaves.
+func (r *RangeFinder) buildProposal(lambdaEx float64) (cands []refineCandidate, unmeasuredMass float64) {
+	res := r.imputeRes
+	if res == nil || res.model == nil {
+		return nil, 0
+	}
+	var totalW, unmeasuredW, qTotal float64
+	var runBuf []tileRun
+	for _, ir := range r.inference.InferredRacks {
+		totalW += ir.Weight
+		key := leaveKey(ir.Leave)
+		if ml, ok := r.measured[key]; ok && ml.count > 0 {
+			continue
+		}
+		unmeasuredW += ir.Weight
+		runBuf = runsOf(ir.Leave, runBuf)
+		q := ir.Weight * (1 + lambdaEx*res.model.uncertainty(runBuf))
+		if q <= 0 {
+			continue
+		}
+		qTotal += q
+		cands = append(cands, refineCandidate{
+			tiles:  ir.Leave,
+			weight: ir.Weight,
+			q:      q,
+			lhat:   math.Exp(res.logCalib + res.model.logImputed(runBuf)),
+		})
+	}
+	if totalW > 0 {
+		unmeasuredMass = unmeasuredW / totalW
+	}
+	if qTotal <= 0 {
+		return nil, unmeasuredMass
+	}
+	// Normalize q and derive u = P/q. An unmeasured leave's stored weight is
+	// P·ℓ̂/maxW, so its prior is Weight·maxW/ℓ̂ — exact, and cheaper than
+	// recomputing combinatorialPrior for tens of thousands of leaves.
+	maxW := math.Exp(res.maxLogW)
+	for i := range cands {
+		cands[i].q /= qTotal
+		prior := 0.0
+		if cands[i].lhat > 0 {
+			prior = cands[i].weight * maxW / cands[i].lhat
+		}
+		cands[i].u = prior / cands[i].q
+	}
+	return cands, unmeasuredMass
+}
+
+// truncateWeights caps importance weights at sqrt(n)·mean (Ionides), bounding
+// the variance a single lucky draw from the model's tail can inject into the
+// lifts. Returns the number of weights that were capped.
+func truncateWeights(cands []refineCandidate) int {
+	if len(cands) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, c := range cands {
+		sum += c.u
+	}
+	limit := math.Sqrt(float64(len(cands))) * sum / float64(len(cands))
+	capped := 0
+	for i := range cands {
+		if cands[i].u > limit {
+			cands[i].u = limit
+			capped++
+		}
+	}
+	return capped
+}
+
+// systematicSample draws m indices proportional to size from the (normalized)
+// probabilities q, using one uniform offset and m equally spaced positions on
+// the CDF. Every item with q ≥ 1/m is drawn at least once, and E[draws of i] =
+// m·q(i) exactly, so the importance weights stay valid while the variance is
+// far below i.i.d. sampling. Returns indices, with repeats where q is large.
+func systematicSample(q []float64, m int, rng *rand.Rand) []int {
+	if m <= 0 || len(q) == 0 {
+		return nil
+	}
+	step := 1.0 / float64(m)
+	pos := rng.Float64() * step
+	out := make([]int, 0, m)
+	cum := 0.0
+	i := 0
+	for len(out) < m && i < len(q) {
+		cum += q[i]
+		for len(out) < m && pos <= cum {
+			out = append(out, i)
+			pos += step
+		}
+		i++
+	}
+	// Floating-point slack can leave the last position just past the final
+	// cumulative total; assign any remainder to the last positive-q item.
+	for len(out) < m {
+		last := len(q) - 1
+		for last > 0 && q[last] <= 0 {
+			last--
+		}
+		out = append(out, last)
+	}
+	return out
+}
+
+// roundStats records one refine round for logging and the stopping rule.
+type roundStats struct {
+	round int
+	// drawn is how many PPS draws the round asked for; distinct is how many
+	// distinct leaves those draws landed on (a leave holding ≥ 1/drawn of the
+	// proposal can come up more than once); evaluated is how many of those
+	// actually finished before the deadline and were recorded.
+	drawn      int
+	distinct   int
+	evaluated  int
+	logRatio   float64 // log R̂: measured mass ÷ predicted mass on this batch
+	seLogRatio float64
+	unmeasured float64 // share of posterior mass still unmeasured
+	converged  bool
+}
+
+// ratioStatistic computes R̂ = Σ u·w / Σ u·ℓ̂ over a freshly evaluated batch —
+// all leaves previously unmeasured, so the predictions are genuinely
+// out-of-sample — together with the linearized standard error of the ratio
+// estimator. This is the loop's convergence test: it asks whether the model
+// was right about the mass it just pointed at.
+func ratioStatistic(us, ws, lhats []float64) (ratio, se float64) {
+	var num, den float64
+	for i := range us {
+		num += us[i] * ws[i]
+		den += us[i] * lhats[i]
+	}
+	if den <= 0 {
+		return 0, 0
+	}
+	ratio = num / den
+	var v float64
+	for i := range us {
+		resid := ws[i] - ratio*lhats[i]
+		v += us[i] * us[i] * resid * resid
+	}
+	se = math.Sqrt(v) / den
+	return ratio, se
+}
+
+// refineRounds runs the measure–impute–recalibrate loop until it converges,
+// exhausts the leave space, covers the posterior mass, runs out of rounds, or
+// runs out of time. It assumes finalizePlacementPosterior has already produced
+// a first posterior from round 0.
+func (r *RangeFinder) refineRounds(ctx context.Context, maxRounds int) {
+	if maxRounds <= 0 || r.acc == nil {
+		return
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for round := 1; round <= maxRounds; round++ {
+		if ctx.Err() != nil {
+			return
+		}
+		r.currentRound = round
+		cands, unmeasuredMass := r.buildProposal(refineExplorationLambda)
+		if len(cands) == 0 {
+			log.Info().Int("round", round).Msg("refine-space-exhausted")
+			return
+		}
+		if unmeasuredMass < refineMassCovered {
+			log.Info().Int("round", round).Float64("unmeasured-mass", unmeasuredMass).
+				Msg("refine-mass-covered")
+			return
+		}
+
+		batch := r.roundBatchSize(ctx, round, maxRounds, len(cands))
+		if batch <= 0 {
+			log.Info().Int("round", round).Msg("refine-budget-exhausted")
+			return
+		}
+		truncated := truncateWeights(cands)
+
+		qs := make([]float64, len(cands))
+		for i, c := range cands {
+			qs[i] = c.q
+		}
+		picks := systematicSample(qs, batch, rng)
+
+		// De-duplicate for evaluation but keep multiplicity in the weights: a
+		// leave drawn twice contributes 2u, and its measurements average into
+		// one w̄. (PPS hands repeats only to leaves with q ≥ 1/m, where the
+		// extra precision is worth the most.)
+		type batchEntry struct {
+			cand int // index into cands
+			mult int
+			w    float64
+			got  bool
+		}
+		entries := make([]batchEntry, 0, len(picks))
+		entryOf := make(map[int]int, len(picks))
+		for _, p := range picks {
+			if at, ok := entryOf[p]; ok {
+				entries[at].mult++
+				continue
+			}
+			entryOf[p] = len(entries)
+			entries = append(entries, batchEntry{cand: p, mult: 1})
+		}
+		toEval := make([][]tilemapping.MachineLetter, len(entries))
+		keyToEntry := make(map[string]int, len(entries))
+		for i, e := range entries {
+			toEval[i] = cands[e.cand].tiles
+			keyToEntry[leaveKey(cands[e.cand].tiles)] = i
+		}
+
+		var mu sync.Mutex
+		err := r.evaluateLeaves(ctx, toEval, func(leave []tilemapping.MachineLetter, lik float64) {
+			mu.Lock()
+			defer mu.Unlock()
+			if i, ok := keyToEntry[leaveKey(leave)]; ok {
+				entries[i].w = lik
+				entries[i].got = true
+			}
+		})
+		if err != nil {
+			log.Err(err).Int("round", round).Msg("refine-evaluate-failed")
+			return
+		}
+
+		// Record the evaluated draws and collect the ratio statistic.
+		var us, ws, lhats []float64
+		evaluated := 0
+		for _, e := range entries {
+			if !e.got {
+				continue // context expired before this one ran
+			}
+			c := cands[e.cand]
+			u := c.u * float64(e.mult)
+			r.recordPlacementSample(c.tiles, e.w, u)
+			// Keep what the model predicted before this measurement: once it
+			// refits below, no out-of-sample prediction for this leave exists
+			// anywhere else.
+			if ml, ok := r.measured[leaveKey(c.tiles)]; ok {
+				ml.predicted = c.lhat
+			}
+			r.refinedCount++
+			evaluated++
+			us = append(us, u)
+			ws = append(ws, e.w)
+			lhats = append(lhats, c.lhat)
+		}
+		if evaluated == 0 {
+			return
+		}
+
+		ratio, se := ratioStatistic(us, ws, lhats)
+		st := roundStats{round: round, drawn: batch, distinct: len(entries),
+			evaluated: evaluated, unmeasured: unmeasuredMass}
+		if ratio > 0 {
+			st.logRatio = math.Log(ratio)
+			st.seLogRatio = se / ratio
+			// Equivalence test, not a significance test: stop only when the
+			// entire interval sits inside the tolerance band. A wide interval
+			// means the batch could not detect miscalibration — that is a
+			// reason to keep measuring, not to declare victory.
+			st.converged = math.Abs(st.logRatio)+2*st.seLogRatio < refineConvergedTol
+		}
+		r.roundLog = append(r.roundLog, st)
+
+		// Refit and re-impute with the new measurements before the next round.
+		r.finalizePlacementPosterior()
+
+		log.Info().Int("round", round).
+			Int("drawn", st.drawn).Int("distinct-leaves", st.distinct).
+			Int("evaluated", st.evaluated).
+			Int("truncated-weights", truncated).
+			Float64("log-ratio", st.logRatio).Float64("se", st.seLogRatio).
+			Float64("unmeasured-mass", unmeasuredMass).
+			Bool("converged", st.converged).
+			Msg("refine-round")
+
+		if st.converged {
+			return
+		}
+	}
+}
+
+// roundBatchSize divides the time left among the rounds left, converting to a
+// leaf count via the evaluation rate observed in round 0. A round smaller than
+// refineMinBatch is not worth running — the ratio statistic would be pure
+// noise — so a thin share is rounded up to the minimum and the loop simply
+// runs fewer, larger rounds. Returns 0 when even one minimum batch will not
+// fit in the time that remains.
+func (r *RangeFinder) roundBatchSize(ctx context.Context, round, maxRounds, candidates int) int {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		// No deadline: take an even slice of the candidate space per round.
+		return min(candidates/maxRounds+1, candidates)
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	roundsLeft := maxRounds - round + 1
+
+	// Evaluations per second, measured on round 0 across all threads.
+	rate := 0.0
+	if r.stage0Elapsed > 0 {
+		rate = float64(r.simCount.Load()) / r.stage0Elapsed.Seconds()
+	}
+	if rate <= 0 {
+		rate = float64(r.threads) * 10 // ~100ms per mini-sim, conservative
+	}
+
+	b := int(rate * remaining.Seconds() / float64(roundsLeft))
+	if b < refineMinBatch {
+		if int(rate*remaining.Seconds()) < refineMinBatch {
+			return 0 // no time for a worthwhile round
+		}
+		b = refineMinBatch
+	}
+	return min(b, candidates)
+}

--- a/rangefinder/refine.go
+++ b/rangefinder/refine.go
@@ -47,8 +47,11 @@ const (
 	// there cannot move the posterior much.
 	refineMassCovered = 0.02
 
-	// refineMinBatch is the smallest worthwhile round; below this the ratio
-	// statistic is too noisy to learn from.
+	// refineMinBatch is the smallest batch whose ratio statistic is trusted
+	// for the stopping rule. Smaller rounds still run — their measurements
+	// are exact either way — but cannot declare convergence. In particular a
+	// one-leaf batch fits R̂ exactly, leaving a zero residual and a zero
+	// standard error, which would otherwise read as perfect calibration.
 	refineMinBatch = 16
 )
 
@@ -393,8 +396,11 @@ func (r *RangeFinder) refineRounds(ctx context.Context, maxRounds int) {
 			// Equivalence test, not a significance test: stop only when the
 			// entire interval sits inside the tolerance band. A wide interval
 			// means the batch could not detect miscalibration — that is a
-			// reason to keep measuring, not to declare victory.
-			st.converged = math.Abs(st.logRatio)+2*st.seLogRatio < refineConvergedTol
+			// reason to keep measuring, not to declare victory. A batch too
+			// small to have an interval worth the name cannot conclude
+			// anything either way.
+			st.converged = evaluated >= refineMinBatch &&
+				math.Abs(st.logRatio)+2*st.seLogRatio < refineConvergedTol
 		}
 		r.roundLog = append(r.roundLog, st)
 
@@ -417,11 +423,15 @@ func (r *RangeFinder) refineRounds(ctx context.Context, maxRounds int) {
 }
 
 // roundBatchSize divides the time left among the rounds left, converting to a
-// leaf count via the evaluation rate observed in round 0. A round smaller than
-// refineMinBatch is not worth running — the ratio statistic would be pure
-// noise — so a thin share is rounded up to the minimum and the loop simply
-// runs fewer, larger rounds. Returns 0 when even one minimum batch will not
-// fit in the time that remains.
+// leaf count via the evaluation rate observed in round 0. A thin share is
+// rounded up to refineMinBatch so the loop runs fewer, larger rounds rather
+// than a string of rounds too small to learn from.
+//
+// It never returns 0 while any time remains. A round below refineMinBatch
+// cannot *conclude* anything — the stopping rule ignores its ratio — but the
+// leaves it measures are still exact posterior weights, and returning 0 here
+// would leave the rest of the budget simply unspent, making inference
+// strictly worse than not splitting the budget at all.
 func (r *RangeFinder) roundBatchSize(ctx context.Context, round, maxRounds, candidates int) int {
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -445,10 +455,8 @@ func (r *RangeFinder) roundBatchSize(ctx context.Context, round, maxRounds, cand
 
 	b := int(rate * remaining.Seconds() / float64(roundsLeft))
 	if b < refineMinBatch {
-		if int(rate*remaining.Seconds()) < refineMinBatch {
-			return 0 // no time for a worthwhile round
-		}
-		b = refineMinBatch
+		// Spend what is left in one go rather than dribbling it away.
+		b = min(refineMinBatch, max(1, int(rate*remaining.Seconds())))
 	}
 	return min(b, candidates)
 }

--- a/rangefinder/refine_test.go
+++ b/rangefinder/refine_test.go
@@ -1,0 +1,173 @@
+package rangefinder
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/matryer/is"
+
+	"github.com/domino14/macondo/montecarlo"
+)
+
+// Systematic PPS must give each item exactly ⌊m·q⌋ or ⌈m·q⌉ draws, whatever
+// the random offset — that expectation is what keeps u = P/q valid.
+func TestSystematicSampleExpectation(t *testing.T) {
+	is := is.New(t)
+	q := []float64{0.5, 0.25, 0.15, 0.09, 0.01}
+	rng := rand.New(rand.NewSource(7))
+
+	for _, m := range []int{4, 8, 20, 100} {
+		totals := make([]int, len(q))
+		trials := 200
+		for tr := 0; tr < trials; tr++ {
+			counts := make([]int, len(q))
+			picks := systematicSample(q, m, rng)
+			is.Equal(len(picks), m) // always exactly m draws
+			for _, p := range picks {
+				counts[p]++
+			}
+			for i := range q {
+				want := float64(m) * q[i]
+				if float64(counts[i]) < math.Floor(want) || float64(counts[i]) > math.Ceil(want) {
+					t.Fatalf("m=%d item %d: drawn %d times, want ⌊%v⌋..⌈%v⌉",
+						m, i, counts[i], want, want)
+				}
+				totals[i] += counts[i]
+			}
+		}
+		// And the mean over trials lands on m·q.
+		for i := range q {
+			got := float64(totals[i]) / float64(trials)
+			want := float64(m) * q[i]
+			if math.Abs(got-want) > 0.5 {
+				t.Fatalf("m=%d item %d: mean draws %v, want %v", m, i, got, want)
+			}
+		}
+	}
+}
+
+// Weight truncation bounds what a single draw from the model's tail can do to
+// the lifts.
+func TestProposalWeightsTruncated(t *testing.T) {
+	is := is.New(t)
+	cands := make([]refineCandidate, 100)
+	for i := range cands {
+		cands[i].u = 1
+	}
+	cands[0].u = 10000 // a leave the model thought was near-impossible
+
+	capped := truncateWeights(cands)
+	is.Equal(capped, 1)
+
+	// limit = sqrt(n)·mean, with mean computed before capping.
+	mean := (10000 + 99) / 100.0
+	limit := math.Sqrt(100) * mean
+	is.True(math.Abs(cands[0].u-limit) < 1e-9)
+	is.Equal(cands[1].u, 1.0) // untouched
+	is.True(cands[0].u < 10000)
+}
+
+// The round's ratio statistic is the out-of-sample calibration check: it must
+// read 1 when the model predicted the batch exactly, and recover a known
+// scale error otherwise, with a standard error that vanishes on a perfect fit.
+func TestRatioStatistic(t *testing.T) {
+	is := is.New(t)
+	us := []float64{1, 2, 0.5, 3}
+	lhats := []float64{0.1, 0.4, 0.02, 0.9}
+
+	perfect := append([]float64{}, lhats...)
+	ratio, se := ratioStatistic(us, perfect, lhats)
+	is.True(math.Abs(ratio-1) < 1e-12)
+	is.True(se < 1e-12)
+
+	doubled := make([]float64, len(lhats))
+	for i, l := range lhats {
+		doubled[i] = 2 * l
+	}
+	ratio, se = ratioStatistic(us, doubled, lhats)
+	is.True(math.Abs(ratio-2) < 1e-12)
+	is.True(se < 1e-12) // a uniform scale error is estimated exactly
+
+	// Scatter around the prediction leaves the ratio near 1 but the standard
+	// error positive, which is what stops the loop from calling it converged.
+	noisy := []float64{0.05, 0.8, 0.02, 0.45}
+	ratio, se = ratioStatistic(us, noisy, lhats)
+	is.True(ratio > 0)
+	is.True(se > 0)
+}
+
+// The ranking view carries each leave's origin round and keeps ranks assigned
+// over the full posterior, so a filtered view still says where its rows sit.
+func TestRankedRacksTagsOriginRound(t *testing.T) {
+	is := is.New(t)
+	r := &RangeFinder{
+		inference: &Inference{
+			InferredRacks: []montecarlo.InferredRack{
+				{Leave: mls(1, 2), Weight: 0.2},
+				{Leave: mls(1, 3), Weight: 0.9},
+				{Leave: mls(2, 3), Weight: 0.5},
+				{Leave: mls(3, 3), Weight: 0.1},
+			},
+		},
+		measured: map[string]*measuredLeave{
+			leaveKey(mls(1, 3)): {count: 2, round: 0},
+			leaveKey(mls(2, 3)): {count: 1, round: 3},
+		},
+	}
+	rows := r.rankedRacks()
+	is.Equal(len(rows), 4)
+
+	// Sorted by weight, ranks 1..n over the whole posterior.
+	is.Equal(rows[0].rank, 1)
+	is.True(rows[0].measured)
+	is.Equal(rows[0].round, 0)
+	is.Equal(rows[0].source(), "measured ×2 r0")
+
+	is.Equal(rows[1].rank, 2)
+	is.Equal(rows[1].round, 3)
+	is.Equal(rows[1].source(), "measured ×1 r3")
+
+	// The imputed ones keep their overall rank, which is the point of the
+	// filtered view: the first imputed leave here sits at rank 3, not 1.
+	is.True(!rows[2].measured)
+	is.Equal(rows[2].rank, 3)
+	is.Equal(rows[2].source(), "imputed")
+
+	// Weight shares are over the full posterior.
+	total := 0.2 + 0.9 + 0.5 + 0.1
+	is.True(math.Abs(rows[0].pct-100*0.9/total) < 1e-9)
+
+	first, count, pct := imputedSummary(rows)
+	is.True(first != nil)
+	is.Equal(first.rank, 3) // not 1: the top of the posterior is measured
+	is.Equal(count, 2)
+	is.True(math.Abs(pct-100*(0.2+0.1)/total) < 1e-9) // the two unmeasured ones
+}
+
+// With everything measured there is no imputed leave to point at.
+func TestImputedSummaryFullyMeasured(t *testing.T) {
+	is := is.New(t)
+	r := &RangeFinder{
+		inference: &Inference{
+			InferredRacks: []montecarlo.InferredRack{{Leave: mls(1, 2), Weight: 1}},
+		},
+		measured: map[string]*measuredLeave{leaveKey(mls(1, 2)): {count: 1}},
+	}
+	first, count, pct := imputedSummary(r.rankedRacks())
+	is.True(first == nil)
+	is.Equal(count, 0)
+	is.Equal(pct, 0.0)
+}
+
+// A degenerate batch must not produce a NaN convergence test.
+func TestRatioStatisticDegenerate(t *testing.T) {
+	is := is.New(t)
+	ratio, se := ratioStatistic(nil, nil, nil)
+	is.Equal(ratio, 0.0)
+	is.Equal(se, 0.0)
+	// All predictions zero: no denominator, no statistic.
+	ratio, se = ratioStatistic([]float64{1}, []float64{0.5}, []float64{0})
+	is.Equal(ratio, 0.0)
+	is.Equal(se, 0.0)
+}

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -121,7 +121,7 @@ func (r *RangeFinder) writeSubleaveTable(ss *strings.Builder,
 	mls []tilemapping.MachineLetter) (lhat float64, ok bool) {
 
 	if r.imputeRes == nil || r.imputeRes.model == nil || r.acc == nil ||
-		r.acc.n == 0 || r.acc.wTotal <= 0 {
+		r.acc.n == 0 || r.acc.likTotal <= 0 {
 		return 0, false
 	}
 	alph := r.origGame.Alphabet()
@@ -131,23 +131,26 @@ func (r *RangeFinder) writeSubleaveTable(ss *strings.Builder,
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
 	runs := runsOf(sorted, nil)
 	terms := mod.subleaveTerms(runs)
-	wMean := r.acc.wTotal / float64(r.acc.n)
+	wMean := r.acc.likTotal / r.acc.wtTotal
 
+	// "ess" is the effective sample size behind the term — the plain
+	// containment count when every draw was prior-sampled (u = 1), smaller
+	// when the draws carried unequal importance weights.
 	fmt.Fprintf(ss, "  %-6s%-8s%-13s%-11s%-9s%-11s%-9s\n",
-		"sub", "n", "E[lik|sub]", "lift", "shrink", "φ", "e^φ")
+		"sub", "ess", "E[lik|sub]", "lift", "shrink", "φ", "e^φ")
 	sumPhi := 0.0
 	for _, t := range terms {
 		sumPhi += t.phi
 		sub := tilemapping.MachineWord(t.tiles).UserVisible(alph)
-		cnt, wsum := r.acc.accStats(t.tiles)
-		if cnt == 0 {
-			fmt.Fprintf(ss, "  %-6s%-8d%-13s%-11s%-9s%-11s%-9s (no data)\n",
-				sub, 0, "—", "—", "—", "0", "1")
+		e, wt, lik := r.acc.accStats(t.tiles)
+		if wt == 0 {
+			fmt.Fprintf(ss, "  %-6s%-8s%-13s%-11s%-9s%-11s%-9s (no data)\n",
+				sub, "0", "—", "—", "—", "0", "1")
 			continue
 		}
-		condMean := wsum / cnt
-		fmt.Fprintf(ss, "  %-6s%-8d%-13.4g%-11.4g%-9.3f%-+11.4g%-9.4g\n",
-			sub, int(cnt), condMean, condMean/wMean, cnt/(cnt+mod.lambda),
+		condMean := lik / wt
+		fmt.Fprintf(ss, "  %-6s%-8.4g%-13.4g%-11.4g%-9.3f%-+11.4g%-9.4g\n",
+			sub, e, condMean, condMean/wMean, e/(e+mod.lambda),
 			t.phi, math.Exp(t.phi))
 	}
 	logCalib := r.imputeRes.logCalib

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -77,7 +77,7 @@ func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
 	srcTag := ""
 	if r.inference.Complete {
 		if ml, ok := r.measured[key]; ok && ml.count > 0 {
-			srcTag = fmt.Sprintf(" [MEASURED ×%d]", ml.count)
+			srcTag = fmt.Sprintf(" [MEASURED ×%d, %s]", ml.count, roundLabel(ml.round))
 		} else {
 			srcTag = " [IMPUTED]"
 		}
@@ -89,12 +89,24 @@ func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
 			100.0*prior, (weight/sumW)/prior)
 	}
 	if ml, ok := r.measured[key]; ok && ml.count > 0 {
-		fmt.Fprintf(&ss, "  measured: evaluated %d time(s), mean likelihood %.6g\n",
-			ml.count, ml.mean())
+		how := "drawn at random from the unseen pool in round 0"
+		if ml.round > 0 {
+			how = fmt.Sprintf("drawn from the imputed posterior in refine round %d", ml.round)
+		}
+		fmt.Fprintf(&ss, "  measured: evaluated %d time(s), mean likelihood %.6g (%s)\n",
+			ml.count, ml.mean(), how)
 		if r.imputeRes != nil && ml.mean() > 0 {
 			fmt.Fprintf(&ss, "  weight = prior × mean likelihood ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
 				prior, ml.mean(), math.Exp(r.imputeRes.maxLogW),
 				math.Exp(math.Log(prior)+math.Log(ml.mean())-r.imputeRes.maxLogW))
+			if ml.predicted > 0 {
+				// The out-of-sample prediction that got this leave selected,
+				// made before it was measured. The final model below has
+				// since been fit on this very measurement, so its comparison
+				// is in-sample; this one is not.
+				fmt.Fprintf(&ss, "  the model predicted %.6g before measuring it — measured/predicted = %.4gx\n",
+					ml.predicted, ml.mean()/ml.predicted)
+			}
 			fmt.Fprintf(&ss, "  imputation model comparison (not used for this leave's weight):\n")
 			if lhat, ok := r.writeSubleaveTable(&ss, mls); ok {
 				fmt.Fprintf(&ss, "  measured/imputed likelihood ratio: %.4gx\n",
@@ -111,6 +123,139 @@ func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
 		}
 	}
 	return ss.String(), nil
+}
+
+// roundLabel names the round a leave was measured in: r0 is the prior-sampled
+// pass (or exhaustive enumeration), r1 and up are the refinement rounds that
+// drew from the imputed posterior.
+func roundLabel(round int) string {
+	return fmt.Sprintf("r%d", round)
+}
+
+// rankedRack is one row of the posterior ranking.
+type rankedRack struct {
+	rank     int // position in the full posterior, not in a filtered view
+	leave    []tilemapping.MachineLetter
+	weight   float64
+	pct      float64 // share of total posterior weight
+	measured bool
+	count    int
+	round    int
+}
+
+func (rr rankedRack) source() string {
+	if !rr.measured {
+		return "imputed"
+	}
+	return fmt.Sprintf("measured ×%d %s", rr.count, roundLabel(rr.round))
+}
+
+// rankedRacks sorts the whole posterior by weight and tags each leave with
+// where its likelihood came from. Ranks are assigned over the full list, so
+// they stay meaningful after filtering.
+func (r *RangeFinder) rankedRacks() []rankedRack {
+	sumW := 0.0
+	for _, ir := range r.inference.InferredRacks {
+		sumW += ir.Weight
+	}
+	ranked := make([]montecarlo.InferredRack, len(r.inference.InferredRacks))
+	copy(ranked, r.inference.InferredRacks)
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].Weight > ranked[j].Weight })
+
+	out := make([]rankedRack, len(ranked))
+	for i, ir := range ranked {
+		row := rankedRack{rank: i + 1, leave: ir.Leave, weight: ir.Weight}
+		if sumW > 0 {
+			row.pct = 100.0 * ir.Weight / sumW
+		}
+		if ml, ok := r.measured[leaveKey(ir.Leave)]; ok && ml.count > 0 {
+			row.measured, row.count, row.round = true, ml.count, ml.round
+		}
+		out[i] = row
+	}
+	return out
+}
+
+// RankedRacks renders the posterior ranking, optionally filtered to just the
+// measured or just the imputed leaves. n ≤ 0 means the default page size.
+// Ranks shown are positions in the full posterior, so a filtered view still
+// says where its rows sit overall.
+func (r *RangeFinder) RankedRacks(filter string, n int) (string, error) {
+	switch filter {
+	case "", "all", "measured", "imputed":
+	default:
+		return "", fmt.Errorf("unknown filter %q: use measured, imputed, or nothing for all", filter)
+	}
+	if len(r.inference.InferredRacks) == 0 {
+		return "No inferences. Run `infer` first.", nil
+	}
+	if n <= 0 {
+		n = 15
+	}
+	alph := r.origGame.Alphabet()
+	rows := r.rankedRacks()
+
+	var ss strings.Builder
+	label := "leaves"
+	if filter != "" && filter != "all" {
+		label = filter + " leaves"
+	}
+	fmt.Fprintf(&ss, "Posterior ranking — top %d %s of %d:\n", n, label, len(rows))
+	fmt.Fprintf(&ss, "  %-6s%-12s%-12s%-12s%-14s\n", "Rank", "Leave", "Weight", "Wt %", "Source")
+
+	shown, cumPct := 0, 0.0
+	for _, row := range rows {
+		if (filter == "measured" && !row.measured) || (filter == "imputed" && row.measured) {
+			continue
+		}
+		fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f%-14s\n", row.rank,
+			tilemapping.MachineWord(row.leave).UserVisible(alph),
+			row.weight, row.pct, row.source())
+		cumPct += row.pct
+		shown++
+		if shown >= n {
+			break
+		}
+	}
+	if shown == 0 {
+		fmt.Fprintf(&ss, "  (none)\n")
+		return ss.String(), nil
+	}
+	fmt.Fprintf(&ss, "  these %d hold %.1f%% of the posterior\n", shown, cumPct)
+	return ss.String(), nil
+}
+
+// imputedSummary finds the highest-weight never-evaluated leave and totals the
+// imputed set's share of the posterior. first is nil when every leave was
+// directly evaluated.
+func imputedSummary(rows []rankedRack) (first *rankedRack, count int, pct float64) {
+	for i := range rows {
+		if rows[i].measured {
+			continue
+		}
+		if first == nil {
+			first = &rows[i]
+		}
+		pct += rows[i].pct
+		count++
+	}
+	return first, count, pct
+}
+
+// firstImputedLine reports where the highest-weight never-evaluated leave sits
+// in the ranking, and how much mass the imputed set holds in total. After a
+// refine run the top of the table is usually all measured — this says where
+// the model is still guessing and how much that guess is worth. Returns "" when
+// the space was evaluated exhaustively and nothing was imputed at all.
+func (r *RangeFinder) firstImputedLine(rows []rankedRack) string {
+	first, count, pct := imputedSummary(rows)
+	if first == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"  highest-weight imputed leave: %s at rank %d of %d (%.2f%% of mass); %d imputed leaves hold %.1f%% in total\n",
+		tilemapping.MachineWord(first.leave).UserVisible(r.origGame.Alphabet()),
+		first.rank, len(rows), first.pct, count, pct)
 }
 
 // writeSubleaveTable prints every sub-multiset φ term of the leave with its
@@ -215,10 +360,22 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 			xfit = fmt.Sprintf(", xfit=%.2fx",
 				math.Exp(r.imputeRes.logCalib-r.imputeRes.logCalibInSample))
 		}
+		refined := ""
+		if r.refinedCount > 0 {
+			// How the refine loop ended, and how close the model's imputed
+			// weights were to the evaluations in its final round.
+			last := r.roundLog[len(r.roundLog)-1]
+			outcome := "budget"
+			if last.converged {
+				outcome = "converged"
+			}
+			refined = fmt.Sprintf(", %d refined over %d round(s), %s (log R̂=%+.3f ±%.3f)",
+				r.refinedCount, len(r.roundLog), outcome, last.logRatio, last.seLogRatio)
+		}
 		headerLine = fmt.Sprintf(
-			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f%s\n",
+			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f%s%s\n",
 			nInferred, src, r.imputeRes.measuredLeaves, 100.0*r.imputeRes.measuredMass,
-			r.imputeRes.imputedLeaves, r.imputeRes.marginalOrder, r.Tau(), ess, xfit)
+			r.imputeRes.imputedLeaves, r.imputeRes.marginalOrder, r.Tau(), ess, xfit, refined)
 	} else if r.exhaustiveTotal > 0 {
 		// Enumeration mode: show leaves simmed vs total, and completion %.
 		pct := 100.0 * float64(nInferred) / float64(r.exhaustiveTotal)
@@ -246,11 +403,7 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 
 		// Top inferred racks by weight
 		ss.WriteString("Top inferred racks (by Bayesian weight):\n")
-		ranked := make([]montecarlo.InferredRack, len(r.inference.InferredRacks))
-		copy(ranked, r.inference.InferredRacks)
-		sort.Slice(ranked, func(i, j int) bool {
-			return ranked[i].Weight > ranked[j].Weight
-		})
+		ranked := r.rankedRacks()
 
 		showSource := r.inference.Complete
 		if showSource {
@@ -259,30 +412,37 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 			fmt.Fprintf(&ss, "  %-6s%-12s%-12s%-12s\n", "Rank", "Leave", "Weight", "Wt %")
 		}
 
+		if showSource && r.refinedCount > 0 {
+			ss.WriteString("  (r0 = prior-sampled exploration; r1+ = drawn from the imputed posterior)\n")
+		}
+
 		showN := min(len(ranked), 15)
 		for i := 0; i < showN; i++ {
-			ir := ranked[i]
-			leaveStr := tilemapping.MachineWord(ir.Leave).UserVisible(alph)
-			wtPct := 100.0 * ir.Weight / sumW
+			row := ranked[i]
+			leaveStr := tilemapping.MachineWord(row.leave).UserVisible(alph)
 			if showSource {
-				src := "imputed"
-				if ml, ok := r.measured[leaveKey(ir.Leave)]; ok && ml.count > 0 {
-					src = fmt.Sprintf("measured ×%d", ml.count)
-				}
-				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f%-14s\n", i+1, leaveStr, ir.Weight, wtPct, src)
+				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f%-14s\n", row.rank, leaveStr,
+					row.weight, row.pct, row.source())
 			} else {
-				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f\n", i+1, leaveStr, ir.Weight, wtPct)
+				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f\n", row.rank, leaveStr,
+					row.weight, row.pct)
 			}
 		}
 		if len(ranked) > showN {
-			fmt.Fprintf(&ss, "  ... and %d more\n", len(ranked)-showN)
+			fmt.Fprintf(&ss, "  ... and %d more (`infer ranks [n] [measured|imputed]` to browse)\n",
+				len(ranked)-showN)
+		}
+		if showSource {
+			// After refinement the visible table is usually all measured, so
+			// say where the model is still guessing.
+			ss.WriteString(r.firstImputedLine(ranked))
 		}
 
 		// Weight concentration summary
 		topN := min(len(ranked), 3)
 		topSum := 0.0
 		for i := 0; i < topN; i++ {
-			topSum += ranked[i].Weight
+			topSum += ranked[i].weight
 		}
 		topPct := 100.0 * topSum / sumW
 		fmt.Fprintf(&ss, "\nWeight concentration: top %d hold %.1f%% of total weight (ESS = %.1f of %d)\n",

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -154,7 +154,13 @@ func (r *RangeFinder) writeSubleaveTable(ss *strings.Builder,
 			t.phi, math.Exp(t.phi))
 	}
 	logCalib := r.imputeRes.logCalib
-	fmt.Fprintf(ss, "  Σφ = %.4g, calibration = %.4g\n", sumPhi, logCalib)
+	if r.imputeRes.crossFitted {
+		fmt.Fprintf(ss, "  Σφ = %.4g, calibration = %.4g (cross-fit over %d folds; in-sample %.4g, ratio %.3gx)\n",
+			sumPhi, logCalib, calibrationFolds, r.imputeRes.logCalibInSample,
+			math.Exp(logCalib-r.imputeRes.logCalibInSample))
+	} else {
+		fmt.Fprintf(ss, "  Σφ = %.4g, calibration = %.4g\n", sumPhi, logCalib)
+	}
 	lhat = math.Exp(logCalib + sumPhi)
 	fmt.Fprintf(ss, "  imputed likelihood ℓ̂ = exp(calibration + Σφ) = %.6g\n", lhat)
 	return lhat, true
@@ -202,10 +208,17 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 		if r.exhaustiveTotal > 0 {
 			src = "enumeration"
 		}
+		xfit := ""
+		if r.imputeRes.crossFitted {
+			// How much the in-sample constant was depressed by the lifts
+			// fitting their own samples: 1.0x means no detectable overfit.
+			xfit = fmt.Sprintf(", xfit=%.2fx",
+				math.Exp(r.imputeRes.logCalib-r.imputeRes.logCalibInSample))
+		}
 		headerLine = fmt.Sprintf(
-			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f\n",
+			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f%s\n",
 			nInferred, src, r.imputeRes.measuredLeaves, 100.0*r.imputeRes.measuredMass,
-			r.imputeRes.imputedLeaves, r.imputeRes.marginalOrder, r.Tau(), ess)
+			r.imputeRes.imputedLeaves, r.imputeRes.marginalOrder, r.Tau(), ess, xfit)
 	} else if r.exhaustiveTotal > 0 {
 		// Enumeration mode: show leaves simmed vs total, and completion %.
 		pct := 100.0 * float64(nInferred) / float64(r.exhaustiveTotal)

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -1,7 +1,9 @@
 package rangefinder
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -9,6 +11,133 @@ import (
 
 	"github.com/domino14/macondo/montecarlo"
 )
+
+// AnalyzeLeave reports the posterior details of one specific leave: weight,
+// rank, posterior share, hypergeometric prior, the posterior/prior lift, and
+// whether the leave was directly measured (with how many evaluations) or
+// imputed from marginal lifts.
+func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
+	if r.inference == nil || len(r.inference.InferredRacks) == 0 {
+		return "", errors.New("no inference available; run `infer` first")
+	}
+	alph := r.origGame.Alphabet()
+	// Uppercase the input: in tile notation lowercase means a blank
+	// designated as that letter, but a kept blank in a leave is just "?",
+	// so treat lowercase as the regular tile.
+	mls, err := tilemapping.ToMachineLetters(strings.ToUpper(leaveStr), alph)
+	if err != nil {
+		return "", err
+	}
+	for _, ml := range mls {
+		if int(ml) >= len(r.inferenceBagMap) {
+			return "", fmt.Errorf("tile %s cannot appear in a leave",
+				ml.UserVisible(alph, false))
+		}
+	}
+	if len(mls) != r.inference.RackLength {
+		return "", fmt.Errorf("leave %s has %d tiles; inferred leaves have %d",
+			leaveStr, len(mls), r.inference.RackLength)
+	}
+	key := leaveKey(mls)
+	display := tilemapping.MachineWord(mls).UserVisible(alph)
+
+	// Find the leave, its rank, and the total weight.
+	sumW := 0.0
+	weight := -1.0
+	for _, ir := range r.inference.InferredRacks {
+		sumW += ir.Weight
+		if weight < 0 && leaveKey(ir.Leave) == key {
+			weight = ir.Weight
+		}
+	}
+	prior := combinatorialPrior(mls, r.inferenceBagMap)
+
+	if weight < 0 {
+		if prior == 0 {
+			return fmt.Sprintf("Leave %s is impossible: its tiles are not all available in the unseen pool.\n", display), nil
+		}
+		if ml, ok := r.measured[key]; ok && ml.count > 0 && ml.sumW <= 0 {
+			return fmt.Sprintf("Leave %s: measured %d time(s) with likelihood 0 — the observed play is never chosen with this leave, so it was excluded from the posterior.\n",
+				display, ml.count), nil
+		}
+		return fmt.Sprintf("Leave %s is not in the posterior (weight below the negligible-mass cutoff).\n", display), nil
+	}
+
+	rank := 1
+	for _, ir := range r.inference.InferredRacks {
+		if ir.Weight > weight {
+			rank++
+		}
+	}
+
+	postPct := 100.0 * weight / sumW
+	var ss strings.Builder
+	fmt.Fprintf(&ss, "Leave %s: weight %.6g, posterior %.6g%% (rank %d of %d)\n",
+		display, weight, postPct, rank, len(r.inference.InferredRacks))
+	if prior > 0 {
+		fmt.Fprintf(&ss, "  prior %.6g%%, posterior/prior lift %.6gx\n",
+			100.0*prior, (weight/sumW)/prior)
+	}
+	if ml, ok := r.measured[key]; ok && ml.count > 0 {
+		fmt.Fprintf(&ss, "  measured: evaluated %d time(s), mean likelihood %.6g\n",
+			ml.count, ml.mean())
+		if r.imputeRes != nil && ml.mean() > 0 {
+			fmt.Fprintf(&ss, "  weight = prior × mean likelihood ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
+				prior, ml.mean(), math.Exp(r.imputeRes.maxLogW),
+				math.Exp(math.Log(prior)+math.Log(ml.mean())-r.imputeRes.maxLogW))
+		}
+	} else if r.inference.Complete {
+		fmt.Fprintf(&ss, "  imputed: never directly evaluated; likelihood estimated from marginal lifts (order ≤%d)\n",
+			r.imputeRes.marginalOrder)
+		r.writeImputationWalkthrough(&ss, mls, prior)
+	}
+	return ss.String(), nil
+}
+
+// writeImputationWalkthrough prints, for an imputed leave, every sub-multiset
+// φ term with its underlying containment stats, then the chain from prior and
+// imputed likelihood to the normalized posterior weight.
+func (r *RangeFinder) writeImputationWalkthrough(ss *strings.Builder,
+	mls []tilemapping.MachineLetter, prior float64) {
+
+	if r.imputeRes == nil || r.imputeRes.model == nil || r.acc == nil ||
+		r.acc.n == 0 || r.acc.wTotal <= 0 || prior <= 0 {
+		return
+	}
+	alph := r.origGame.Alphabet()
+	mod := r.imputeRes.model
+	sorted := make([]tilemapping.MachineLetter, len(mls))
+	copy(sorted, mls)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	runs := runsOf(sorted, nil)
+	terms := mod.subleaveTerms(runs)
+	wMean := r.acc.wTotal / float64(r.acc.n)
+
+	fmt.Fprintf(ss, "  %-6s%-8s%-13s%-11s%-9s%-11s%-9s\n",
+		"sub", "n", "E[lik|sub]", "lift", "shrink", "φ", "e^φ")
+	sumPhi := 0.0
+	for _, t := range terms {
+		sumPhi += t.phi
+		sub := tilemapping.MachineWord(t.tiles).UserVisible(alph)
+		cnt, wsum := r.acc.accStats(t.tiles)
+		if cnt == 0 {
+			fmt.Fprintf(ss, "  %-6s%-8d%-13s%-11s%-9s%-11s%-9s (no data)\n",
+				sub, 0, "—", "—", "—", "0", "1")
+			continue
+		}
+		condMean := wsum / cnt
+		fmt.Fprintf(ss, "  %-6s%-8d%-13.4g%-11.4g%-9.3f%-+11.4g%-9.4g\n",
+			sub, int(cnt), condMean, condMean/wMean, cnt/(cnt+mod.lambda),
+			t.phi, math.Exp(t.phi))
+	}
+	logCalib := r.imputeRes.logCalib
+	fmt.Fprintf(ss, "  Σφ = %.4g, calibration = %.4g\n", sumPhi, logCalib)
+	lhat := math.Exp(logCalib + sumPhi)
+	fmt.Fprintf(ss, "  imputed likelihood ℓ̂ = exp(calibration + Σφ) = %.6g\n", lhat)
+	fmt.Fprintf(ss, "  weight = prior × ℓ̂ ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
+		prior, lhat, math.Exp(r.imputeRes.maxLogW),
+		math.Exp(math.Log(prior)+logCalib+sumPhi-r.imputeRes.maxLogW))
+}
 
 func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 	totalCt := float64(0)
@@ -44,7 +173,19 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 	}
 
 	var headerLine string
-	if r.exhaustiveTotal > 0 {
+	if r.inference.Complete && r.imputeRes != nil {
+		// Complete-posterior mode (tile placements): every feasible leave
+		// has a weight — evaluated leaves keep their measured likelihood,
+		// the rest are imputed from marginal lifts.
+		src := "MC sampling"
+		if r.exhaustiveTotal > 0 {
+			src = "enumeration"
+		}
+		headerLine = fmt.Sprintf(
+			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f\n",
+			nInferred, src, r.imputeRes.measuredLeaves, 100.0*r.imputeRes.measuredMass,
+			r.imputeRes.imputedLeaves, r.imputeRes.marginalOrder, r.Tau(), ess)
+	} else if r.exhaustiveTotal > 0 {
 		// Enumeration mode: show leaves simmed vs total, and completion %.
 		pct := 100.0 * float64(nInferred) / float64(r.exhaustiveTotal)
 		complete := "complete"
@@ -54,7 +195,7 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 		headerLine = fmt.Sprintf("Inferred %d of %d leaves (%.1f%%, %s), tau=%.3f, ESS=%.1f\n",
 			nInferred, r.exhaustiveTotal, pct, complete, r.Tau(), ess)
 	} else {
-		// Monte Carlo sampling mode.
+		// Monte Carlo sampling mode (exchanges, or no posterior was built).
 		iterations := r.iterationCount
 		acceptRate := 0.0
 		if iterations > 0 {
@@ -77,14 +218,27 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 			return ranked[i].Weight > ranked[j].Weight
 		})
 
-		fmt.Fprintf(&ss, "  %-6s%-12s%-12s%-12s\n", "Rank", "Leave", "Weight", "Wt %")
+		showSource := r.inference.Complete
+		if showSource {
+			fmt.Fprintf(&ss, "  %-6s%-12s%-12s%-12s%-14s\n", "Rank", "Leave", "Weight", "Wt %", "Source")
+		} else {
+			fmt.Fprintf(&ss, "  %-6s%-12s%-12s%-12s\n", "Rank", "Leave", "Weight", "Wt %")
+		}
 
 		showN := min(len(ranked), 15)
 		for i := 0; i < showN; i++ {
 			ir := ranked[i]
 			leaveStr := tilemapping.MachineWord(ir.Leave).UserVisible(alph)
 			wtPct := 100.0 * ir.Weight / sumW
-			fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f\n", i+1, leaveStr, ir.Weight, wtPct)
+			if showSource {
+				src := "imputed"
+				if ml, ok := r.measured[leaveKey(ir.Leave)]; ok && ml.count > 0 {
+					src = fmt.Sprintf("measured ×%d", ml.count)
+				}
+				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f%-14s\n", i+1, leaveStr, ir.Weight, wtPct, src)
+			} else {
+				fmt.Fprintf(&ss, "  %-6d%-12s%-12.4f%-12.1f\n", i+1, leaveStr, ir.Weight, wtPct)
+			}
 		}
 		if len(ranked) > showN {
 			fmt.Fprintf(&ss, "  ... and %d more\n", len(ranked)-showN)

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -72,8 +72,18 @@ func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
 
 	postPct := 100.0 * weight / sumW
 	var ss strings.Builder
-	fmt.Fprintf(&ss, "Leave %s: weight %.6g, posterior %.6g%% (rank %d of %d)\n",
-		display, weight, postPct, rank, len(r.inference.InferredRacks))
+	// Lead with the leave's provenance so the reader knows up front whether
+	// the weight below comes from direct evaluation or the marginal model.
+	srcTag := ""
+	if r.inference.Complete {
+		if ml, ok := r.measured[key]; ok && ml.count > 0 {
+			srcTag = fmt.Sprintf(" [MEASURED ×%d]", ml.count)
+		} else {
+			srcTag = " [IMPUTED]"
+		}
+	}
+	fmt.Fprintf(&ss, "Leave %s%s: weight %.6g, posterior %.6g%% (rank %d of %d)\n",
+		display, srcTag, weight, postPct, rank, len(r.inference.InferredRacks))
 	if prior > 0 {
 		fmt.Fprintf(&ss, "  prior %.6g%%, posterior/prior lift %.6gx\n",
 			100.0*prior, (weight/sumW)/prior)

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -369,8 +369,22 @@ func (r *RangeFinder) AnalyzeInferences(detailed bool) string {
 			if last.converged {
 				outcome = "converged"
 			}
-			refined = fmt.Sprintf(", %d refined over %d round(s), %s (log R̂=%+.3f ±%.3f)",
-				r.refinedCount, len(r.roundLog), outcome, last.logRatio, last.seLogRatio)
+			// The batch size belongs with the ratio: a round of one or two
+			// leaves fits R̂ almost exactly and reports a near-zero standard
+			// error, which would otherwise read as a confident verdict rather
+			// than the non-result it is.
+			verdict := fmt.Sprintf("log R̂=%+.3f ±%.3f over %d",
+				last.logRatio, last.seLogRatio, last.evaluated)
+			if last.evaluated < refineMinBatch {
+				noun := "leaves"
+				if last.evaluated == 1 {
+					noun = "leaf"
+				}
+				verdict = fmt.Sprintf("last round only %d %s, too few to test calibration",
+					last.evaluated, noun)
+			}
+			refined = fmt.Sprintf(", %d refined over %d round(s), %s (%s)",
+				r.refinedCount, len(r.roundLog), outcome, verdict)
 		}
 		headerLine = fmt.Sprintf(
 			"Complete posterior over %d leaves (%s): %d measured holding %.1f%% of mass, %d imputed (marginal order ≤%d), tau=%.3f, ESS=%.1f%s%s\n",

--- a/rangefinder/stats.go
+++ b/rangefinder/stats.go
@@ -85,24 +85,34 @@ func (r *RangeFinder) AnalyzeLeave(leaveStr string) (string, error) {
 			fmt.Fprintf(&ss, "  weight = prior × mean likelihood ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
 				prior, ml.mean(), math.Exp(r.imputeRes.maxLogW),
 				math.Exp(math.Log(prior)+math.Log(ml.mean())-r.imputeRes.maxLogW))
+			fmt.Fprintf(&ss, "  imputation model comparison (not used for this leave's weight):\n")
+			if lhat, ok := r.writeSubleaveTable(&ss, mls); ok {
+				fmt.Fprintf(&ss, "  measured/imputed likelihood ratio: %.4gx\n",
+					ml.mean()/lhat)
+			}
 		}
 	} else if r.inference.Complete {
 		fmt.Fprintf(&ss, "  imputed: never directly evaluated; likelihood estimated from marginal lifts (order ≤%d)\n",
 			r.imputeRes.marginalOrder)
-		r.writeImputationWalkthrough(&ss, mls, prior)
+		if lhat, ok := r.writeSubleaveTable(&ss, mls); ok && prior > 0 {
+			fmt.Fprintf(&ss, "  weight = prior × ℓ̂ ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
+				prior, lhat, math.Exp(r.imputeRes.maxLogW),
+				math.Exp(math.Log(prior)+math.Log(lhat)-r.imputeRes.maxLogW))
+		}
 	}
 	return ss.String(), nil
 }
 
-// writeImputationWalkthrough prints, for an imputed leave, every sub-multiset
-// φ term with its underlying containment stats, then the chain from prior and
-// imputed likelihood to the normalized posterior weight.
-func (r *RangeFinder) writeImputationWalkthrough(ss *strings.Builder,
-	mls []tilemapping.MachineLetter, prior float64) {
+// writeSubleaveTable prints every sub-multiset φ term of the leave with its
+// underlying containment stats, then Σφ, the calibration constant, and the
+// model's imputed likelihood ℓ̂, which it returns. ok is false (nothing
+// printed) when there is no imputation model to consult.
+func (r *RangeFinder) writeSubleaveTable(ss *strings.Builder,
+	mls []tilemapping.MachineLetter) (lhat float64, ok bool) {
 
 	if r.imputeRes == nil || r.imputeRes.model == nil || r.acc == nil ||
-		r.acc.n == 0 || r.acc.wTotal <= 0 || prior <= 0 {
-		return
+		r.acc.n == 0 || r.acc.wTotal <= 0 {
+		return 0, false
 	}
 	alph := r.origGame.Alphabet()
 	mod := r.imputeRes.model
@@ -132,11 +142,9 @@ func (r *RangeFinder) writeImputationWalkthrough(ss *strings.Builder,
 	}
 	logCalib := r.imputeRes.logCalib
 	fmt.Fprintf(ss, "  Σφ = %.4g, calibration = %.4g\n", sumPhi, logCalib)
-	lhat := math.Exp(logCalib + sumPhi)
+	lhat = math.Exp(logCalib + sumPhi)
 	fmt.Fprintf(ss, "  imputed likelihood ℓ̂ = exp(calibration + Σφ) = %.6g\n", lhat)
-	fmt.Fprintf(ss, "  weight = prior × ℓ̂ ÷ max = %.4g × %.4g ÷ %.4g = %.6g\n",
-		prior, lhat, math.Exp(r.imputeRes.maxLogW),
-		math.Exp(math.Log(prior)+logCalib+sumPhi-r.imputeRes.maxLogW))
+	return lhat, true
 }
 
 func (r *RangeFinder) AnalyzeInferences(detailed bool) string {

--- a/shell/api.go
+++ b/shell/api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/domino14/macondo/move"
 	"github.com/domino14/macondo/movegen"
 	"github.com/domino14/macondo/preendgame"
+	"github.com/domino14/macondo/rangefinder"
 	wmppkg "github.com/domino14/macondo/wmp"
 )
 
@@ -1101,6 +1102,7 @@ func (sc *ShellController) inferPrepare(cmd *shellcmd) (*inferParams, error) {
 	var err error
 	var threads, timesec, simIters, maxLeaves int
 	tau := 0.0
+	rounds := rangefinder.DefaultMaxRefineRounds
 
 	for opt := range cmd.options {
 		switch opt {
@@ -1134,6 +1136,12 @@ func (sc *ShellController) inferPrepare(cmd *shellcmd) (*inferParams, error) {
 				return nil, err
 			}
 
+		case "rounds":
+			rounds, err = cmd.options.Int(opt)
+			if err != nil {
+				return nil, err
+			}
+
 		default:
 			return nil, errors.New("option " + opt + " not recognized")
 		}
@@ -1151,6 +1159,9 @@ func (sc *ShellController) inferPrepare(cmd *shellcmd) (*inferParams, error) {
 	// Always set maxLeaves so a previous call's value doesn't persist.
 	// 0 means "use default" inside Infer (DefaultMaxEnumeratedLeaves).
 	sc.rangefinder.SetMaxEnumeratedLeaves(maxLeaves)
+	// Always set rounds so a previous call's value doesn't persist. 0 turns
+	// the refine loop off, leaving single-stage inference.
+	sc.rangefinder.SetMaxRounds(rounds)
 	if timesec == 0 {
 		timesec = 60
 	}
@@ -1215,6 +1226,27 @@ func (sc *ShellController) infer(cmd *shellcmd) (*Response, error) {
 
 		case "output":
 			return msg(sc.rangefinder.AnalyzeInferences(false)), nil
+
+		case "ranks":
+			// infer ranks [n] [measured|imputed], in either order.
+			filter, n := "", 0
+			for _, a := range cmd.args[1:] {
+				switch a {
+				case "measured", "imputed", "all":
+					filter = a
+				default:
+					parsed, err := strconv.Atoi(a)
+					if err != nil || parsed <= 0 {
+						return nil, errors.New("usage: infer ranks [n] [measured|imputed], e.g. `infer ranks 50 imputed`")
+					}
+					n = parsed
+				}
+			}
+			out, err := sc.rangefinder.RankedRacks(filter, n)
+			if err != nil {
+				return nil, err
+			}
+			return msg(out), nil
 
 		case "leave":
 			if len(cmd.args) < 2 {

--- a/shell/api.go
+++ b/shell/api.go
@@ -1216,6 +1216,20 @@ func (sc *ShellController) infer(cmd *shellcmd) (*Response, error) {
 		case "output":
 			return msg(sc.rangefinder.AnalyzeInferences(false)), nil
 
+		case "leave":
+			if len(cmd.args) < 2 {
+				return nil, errors.New("usage: infer leave <LEAVE> [<LEAVE> ...], e.g. `infer leave ITZ`")
+			}
+			var sb strings.Builder
+			for _, leaveStr := range cmd.args[1:] {
+				analysis, err := sc.rangefinder.AnalyzeLeave(leaveStr)
+				if err != nil {
+					return nil, err
+				}
+				sb.WriteString(analysis)
+			}
+			return msg(sb.String()), nil
+
 		default:
 			return nil, errors.New("don't recognize " + cmd.args[0])
 		}

--- a/shell/helptext/infer.txt
+++ b/shell/helptext/infer.txt
@@ -39,11 +39,19 @@ Optional arguments:
     `infer log` will log to a temporary file.
 
     `infer details` shows detailed inference output including:
-      - Top 15 inferred racks ranked by Bayesian weight
+      - Top 15 inferred racks ranked by Bayesian weight, each marked as
+        "measured ×N" (directly evaluated N times with mini-sims) or
+        "imputed" (likelihood estimated from marginal lifts)
       - Weight concentration and effective sample size (ESS)
       - Per-tile found vs expected percentages
 
     `infer output` re-displays the summary bins from the last inference.
+
+    `infer leave <LEAVE> [<LEAVE> ...]` looks up specific leaves in the
+    posterior, e.g. `infer leave ITZ` or `infer leave ITZ AEZ`. For each
+    leave it shows its weight, posterior share and rank, the hypergeometric
+    prior, the posterior/prior lift, and whether it was measured (with the
+    evaluation count and mean likelihood) or imputed.
 
 Understanding the output:
 

--- a/shell/helptext/infer.txt
+++ b/shell/helptext/infer.txt
@@ -40,10 +40,29 @@ Imputation (tile plays only):
     combines those lifts — without double-counting overlapping evidence — into
     an estimated likelihood for each never-evaluated leave. The result is a
     complete posterior over every feasible leave. Directly evaluated leaves
-    are tagged "measured", the rest "imputed". This happens automatically;
-    there are no extra options. Exchange inference still uses plain Monte
-    Carlo sampling. Sims automatically sample from the complete posterior
-    when one is available. See docs/leave_imputation.md for the math.
+    are tagged "measured", the rest "imputed". Exchange inference still uses
+    plain Monte Carlo sampling. Sims automatically sample from the complete
+    posterior when one is available. See docs/leave_imputation.md for the math.
+
+Refinement rounds:
+
+    Inference alternates measuring and imputing. Round 0 draws racks at
+    random from the unseen pool — blind exploration, and the only part that
+    is not steered by the model. It gets 40% of the time budget. Each later
+    round then draws leaves from the *current* posterior, favouring high
+    weight but with a bonus for leaves whose lifts rest on thin evidence,
+    evaluates them with real mini-sims, and refits. So leaves the model
+    thinks are strong get formally checked instead of taken on faith, and
+    what is learned feeds the next round's targeting.
+
+    Each round reports log R̂: the log ratio of measured to imputed likelihood
+    mass over that round's leaves, all of which were unmeasured beforehand —
+    an out-of-sample verdict on the model. 0 means the model was right about
+    the mass it pointed at. The loop stops when that ratio's whole confidence
+    interval fits inside ±10%, when the unmeasured leaves hold under 2% of
+    the posterior, when every leave has been measured, or when the rounds or
+    the clock run out. See -rounds and
+    docs/development/iterative_inference_plan.md.
 
 Note: Sometimes the inference engine will display "No inference details". It
 is not broken; it was unable to find racks where the opponent's play ranked
@@ -54,20 +73,48 @@ Optional arguments:
 
     `infer details` shows detailed inference output including:
       - Top 15 inferred racks ranked by Bayesian weight, each marked as
-        "measured ×N" (directly evaluated N times with mini-sims) or
-        "imputed" (likelihood estimated from marginal lifts)
+        "measured ×N rR" (directly evaluated N times with mini-sims, first
+        drawn in round R) or "imputed" (likelihood estimated from marginal
+        lifts). r0 is the prior-sampled pass; r1 and up are refinement
+        rounds, so "measured ×1 r3" means the model pointed at that leave in
+        round 3 and it was then evaluated for real.
+      - Where the highest-weight *imputed* leave sits in the ranking, and how
+        much mass the imputed set holds. After refinement the visible table
+        is usually all measured, so this is the pointer to where the model is
+        still guessing. Omitted when the space was evaluated exhaustively.
       - Weight concentration and effective sample size (ESS)
       - Per-tile found vs expected percentages
 
     `infer output` re-displays the summary bins from the last inference.
 
+    `infer ranks [n] [measured|imputed]` browses the full posterior ranking,
+    not just the top 15. Ranks shown are positions in the whole posterior, so
+    a filtered view still says where its rows sit:
+
+        infer ranks 50            top 50 leaves
+        infer ranks imputed       top 15 never-evaluated leaves
+        infer ranks 30 imputed    top 30 never-evaluated leaves
+        infer ranks 20 measured   top 20 directly evaluated leaves
+
+    `infer ranks imputed` is the quick way to see what the model is still
+    extrapolating and how far down the ranking it starts.
+
     `infer leave <LEAVE> [<LEAVE> ...]` looks up specific leaves in the
     posterior, e.g. `infer leave ITZ` or `infer leave ITZ AEZ`. Each leave
-    is tagged [MEASURED ×n] or [IMPUTED] and shows its weight, posterior
+    is tagged [MEASURED ×n, rR] or [IMPUTED] and shows its weight, posterior
     share and rank, the hypergeometric prior, and the posterior/prior lift,
     followed by a calculation walkthrough: the per-subleave lift/φ table and
-    the exact chain from prior and likelihood to the final weight. For
-    measured leaves the table is shown as a comparison, ending with the
+    the exact chain from prior and likelihood to the final weight.
+
+    A measured leave also says how it was selected — drawn at random in round
+    0, or drawn from the imputed posterior in refine round R — and for the
+    latter, what the model predicted for it *before* it was measured. That
+    prediction is genuinely out of sample; the model has since been refit on
+    the measurement, so the comparison table below it is not. A large
+    measured/predicted ratio is the model having underestimated a strong
+    leave, which is exactly what refinement exists to catch.
+
+    For measured leaves the φ table is shown as a comparison, ending with the
     measured/imputed likelihood ratio — a ratio far from 1 on a ×1 leave
     suggests a noisy single evaluation.
 
@@ -146,3 +193,12 @@ Options:
 
     Defaults to 5000. Set to 0 to use the default. Set to 1 to always use
     Monte Carlo sampling (useful for comparison).
+
+    -rounds 6
+
+    Maximum number of refinement rounds after round 0 (see "Refinement rounds"
+    above). The loop usually stops earlier — on convergence, mass coverage, or
+    the time budget — so this is a ceiling, not a target. Set to 0 for
+    single-stage inference: round 0 gets the whole budget and nothing is
+    re-measured, which is the useful comparison when judging whether
+    refinement helped. Defaults to 6.

--- a/shell/helptext/infer.txt
+++ b/shell/helptext/infer.txt
@@ -31,6 +31,20 @@ When the inferrer is done running, it prints out stats for the tiles.
 Inferences are saved in memory. You can sim using these inferences.
 See `help sim` or do `sim -useinferences weightedrandom`.
 
+Imputation (tile plays only):
+
+    Within the time budget the engine can directly evaluate only some of the
+    feasible leaves. For tile-play inference it fills in the rest by
+    imputation: for every tile, pair, and triple it tracks how much more (or
+    less) often leaves containing it produced the observed play ("lift"), and
+    combines those lifts — without double-counting overlapping evidence — into
+    an estimated likelihood for each never-evaluated leave. The result is a
+    complete posterior over every feasible leave. Directly evaluated leaves
+    are tagged "measured", the rest "imputed". This happens automatically;
+    there are no extra options. Exchange inference still uses plain Monte
+    Carlo sampling. Sims automatically sample from the complete posterior
+    when one is available. See docs/leave_imputation.md for the math.
+
 Note: Sometimes the inference engine will display "No inference details". It
 is not broken; it was unable to find racks where the opponent's play ranked
 highly enough for it to be able to infer anything.
@@ -48,10 +62,14 @@ Optional arguments:
     `infer output` re-displays the summary bins from the last inference.
 
     `infer leave <LEAVE> [<LEAVE> ...]` looks up specific leaves in the
-    posterior, e.g. `infer leave ITZ` or `infer leave ITZ AEZ`. For each
-    leave it shows its weight, posterior share and rank, the hypergeometric
-    prior, the posterior/prior lift, and whether it was measured (with the
-    evaluation count and mean likelihood) or imputed.
+    posterior, e.g. `infer leave ITZ` or `infer leave ITZ AEZ`. Each leave
+    is tagged [MEASURED ×n] or [IMPUTED] and shows its weight, posterior
+    share and rank, the hypergeometric prior, and the posterior/prior lift,
+    followed by a calculation walkthrough: the per-subleave lift/φ table and
+    the exact chain from prior and likelihood to the final weight. For
+    measured leaves the table is shown as a comparison, ending with the
+    measured/imputed likelihood ratio — a ratio far from 1 on a ×1 leave
+    suggests a noisy single evaluation.
 
 Understanding the output:
 

--- a/shell/sim.go
+++ b/shell/sim.go
@@ -302,9 +302,15 @@ func (sc *ShellController) setSimmerParams(simmer *montecarlo.Simmer, params sim
 	}
 
 	if params.inferMode != montecarlo.InferenceOff {
-		simmer.SetInferences(sc.rangefinder.Inferences().InferredRacks,
-			sc.rangefinder.Inferences().RackLength,
-			params.inferMode)
+		inferences := sc.rangefinder.Inferences()
+		mode := params.inferMode
+		// Tile-placement inference produces a complete posterior over every
+		// feasible leave; sample from it directly instead of gating between
+		// inferred racks and random draws.
+		if mode == montecarlo.InferenceWeightedRandomRacks && inferences.Complete {
+			mode = montecarlo.InferenceCompletePosterior
+		}
+		simmer.SetInferences(inferences.InferredRacks, inferences.RackLength, mode)
 	}
 	if len(params.avoidTrimMoves) > 0 {
 		simmer.AvoidPruningMoves(params.avoidTrimMoves)

--- a/shell/specs.go
+++ b/shell/specs.go
@@ -186,7 +186,7 @@ func init() {
 
 	registerSpec(&CommandSpec{
 		Name:  "infer",
-		Verbs: []string{"log", "details", "output"},
+		Verbs: []string{"log", "details", "output", "leave"},
 		Options: []Option{
 			{Name: "threads", Type: OptInt},
 			{Name: "time", Type: OptInt},

--- a/shell/specs.go
+++ b/shell/specs.go
@@ -186,7 +186,7 @@ func init() {
 
 	registerSpec(&CommandSpec{
 		Name:  "infer",
-		Verbs: []string{"log", "details", "output", "leave"},
+		Verbs: []string{"log", "details", "output", "leave", "ranks"},
 		Options: []Option{
 			{Name: "threads", Type: OptInt},
 			{Name: "time", Type: OptInt},
@@ -194,6 +194,7 @@ func init() {
 
 			{Name: "inferenceiters", Type: OptInt},
 			{Name: "maxleaves", Type: OptInt},
+			{Name: "rounds", Type: OptInt},
 		},
 	})
 


### PR DESCRIPTION
## Summary

Tile-placement inference now produces a **complete Bayesian posterior over every feasible opponent leave**, replacing the sigmoid gate that blended inferred racks with uniform random draws in the simmer.

- **Measured leaves** (directly evaluated within the time budget) keep `prior × mean measured likelihood`; leaves measured with likelihood 0 are excluded as genuinely impossible.
- **Unmeasured leaves** get likelihoods imputed from containment-marginal lifts of the evaluated set — `lift(S) = E[likelihood | S ⊆ leave] / E[likelihood]` for singles/pairs/triples — combined via Möbius inversion on the sub-multiset (divisor) lattice so each order only contributes information not already explained by its parts (handles repeated tiles correctly, e.g. `φ({A,A}) = log lift(AA) − φ(A)`). Shrinkage (λ=10) and clamps guard thin support. When untruncated, the expansion telescopes exactly to the full-leave lift (tested).
- **Calibration is moment-matched** to the arithmetic mean of measured likelihoods: `Σc·exp(logCalib + Σφ) = Σc·w`. An earlier mean-of-logs anchor targeted the geometric mean, which for the heavily right-skewed softmax likelihoods at low tau sat orders of magnitude (~1200× in a real position) below the arithmetic scale, silently starving every imputed leaf of posterior mass.
- The simmer samples opponent leaves directly from the posterior via CDF binary search (`InferenceCompletePosterior`); elite bot, shell sim, and the inferdiag harness use it when available. Exchange inference still uses the legacy path (known follow-up).

## New shell command

`infer leave <tiles>` reports a leave's weight, rank, posterior share, and prior lift — and for imputed leaves, a full calculation walkthrough:

```
Leave ITZ: weight 5.01482e-06, posterior 0.000139005% (rank 212 of 2973)
  prior 0.0472272%, posterior/prior lift 0.00294332x
  imputed: never directly evaluated; likelihood estimated from marginal lifts (order ≤2)
  sub   n       E[lik|sub]   lift       shrink   φ          e^φ
  I     570     0.003499     0.7902     0.983    -0.2314    0.7935
  T     366     0.001496     0.3378     0.973    -1.056     0.3477
  Z     72      0.1243       28.08      0.878    +2.928     18.69
  IT    72      4.206e-05    0.009499   0.878    -2.022     0.1324
  IZ    14      0.1419       32.06      0.583    +0.4496    1.568
  TZ    9       0.06007      13.57      0.474    +0.3485    1.417
  Σφ = 0.4168, calibration = -12.51
  imputed likelihood ℓ̂ = exp(calibration + Σφ) = 5.58869e-06
  weight = prior × ℓ̂ ÷ max = 0.0004723 × 5.589e-06 ÷ 0.0005263 = 5.01482e-06
```

The final line reproduces the stored weight exactly — a built-in self-check that the display matches the engine. (Output above is from before the calibration fix; it's how the bias was found.)

Full math writeup in `docs/leave_imputation.md`.

## Also fixed

Monte Carlo dedup kept only the first weight per distinct leave, silently discarding prior multiplicity.

## Test plan

- `go test ./rangefinder/ ./montecarlo/` — green on this branch.
- Unit tests pin the math: distinct sub-multiset accumulation, exact Möbius telescoping, moment-matched calibration identity, fully-measured posteriors exactly Bayesian, imputed lift ratios, no-signal degrades to prior, zero-measured exclusion, and walkthrough weight reconstruction.
- k=6 worst case (near-full bag): ~737K leaves imputed in ~54ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)