### PR TITLE
Analyzer improvements: mistake grading, sim ordering, batch folders

### DIFF
--- a/ai/bot/elite.go
+++ b/ai/bot/elite.go
@@ -65,10 +65,10 @@ func eliteBestPlay(ctx context.Context, p *BotTurnPlayer) (*move.Move, error) {
 	} else if unseen > 7 && unseen <= 8 {
 		usePreendgame = true
 	} else if unseen > 8 && unseen <= 14 {
-		moves = p.GenerateMoves(80)
+		moves = p.GenerateMoves(100)
 		simPlies = unseen
 	} else {
-		moves = p.GenerateMoves(40)
+		moves = p.GenerateMoves(100)
 		if p.minSimPlies > 2 {
 			simPlies = p.minSimPlies
 		} else {

--- a/gameanalysis/analyzer.go
+++ b/gameanalysis/analyzer.go
@@ -86,10 +86,10 @@ type AnalysisConfig struct {
 // DefaultAnalysisConfig returns sensible defaults
 func DefaultAnalysisConfig() *AnalysisConfig {
 	return &AnalysisConfig{
-		SimPlaysEarlyMid:        40,
+		SimPlaysEarlyMid:        100,
 		SimPliesEarlyMid:        5,
 		SimStopEarlyMid:         99,
-		SimPlaysEarlyPreEndgame: 80,
+		SimPlaysEarlyPreEndgame: 100,
 		SimPliesEarlyPreEndgame: 10,
 		SimStopEarlyPreEndgame:  99,
 		PEGEarlyCutoff:          true,

--- a/gameanalysis/analyzer.go
+++ b/gameanalysis/analyzer.go
@@ -717,18 +717,15 @@ func (a *Analyzer) analyzeWithSim(ctx context.Context, g *game.Game, analysis *T
 	analysis.WinProbLoss = analysis.OptimalWinProb - analysis.PlayedWinProb
 	analysis.WasOptimal = analysis.OptimalMove.Equals(analysis.PlayedMove, checkTrans, true)
 
-	// When all plays are near 0% or 100% win probability, win prob loss is
-	// meaningless. Use equity difference as a spread-based tiebreaker instead,
-	// mirroring how PEG handles tied win probabilities.
-	if !analysis.WasOptimal && playedFound {
-		nearZero := analysis.OptimalWinProb < blowoutWinProbThreshold
-		nearOne := analysis.OptimalWinProb > 1-blowoutWinProbThreshold
-		if nearZero || nearOne {
-			optimalEquity := simmedPlays[0].EquityMean()
-			equityDiff := optimalEquity - playedEquity
-			if equityDiff > 0.5 {
-				analysis.SpreadLoss = int16(equityDiff + 0.5)
-			}
+	// When both plays being compared are near 0% or 100% win probability, win
+	// prob loss is meaningless. Use equity difference as a spread-based
+	// tiebreaker instead, mirroring how PEG handles tied win probabilities.
+	if !analysis.WasOptimal && playedFound &&
+		tiebreakByEquity(analysis.OptimalWinProb, analysis.PlayedWinProb) {
+		optimalEquity := simmedPlays[0].EquityMean()
+		equityDiff := optimalEquity - playedEquity
+		if equityDiff > 0.5 {
+			analysis.SpreadLoss = int16(equityDiff + 0.5)
 		}
 	}
 
@@ -741,6 +738,25 @@ func (a *Analyzer) analyzeWithSim(ctx context.Context, g *game.Game, analysis *T
 	analysis.TopSimPlays = extractTopSimPlays(simmedPlays, analysis.PlayedMove, checkTrans, 5)
 
 	return nil
+}
+
+// tiebreakByEquity reports whether the win probabilities of the optimal and
+// played moves are too saturated to tell them apart, so that the comparison
+// should fall back to equity.
+//
+// The optimal play is the maximum of the field, so a near-zero optimal win prob
+// means every play is hopeless and win% genuinely carries no signal. A
+// near-one optimal win prob says nothing about the rest of the field, though:
+// the played move can still have a real losing chance, and that difference is
+// exactly what the analysis is trying to measure. So the near-one case has to
+// check the played move too — the same conjunction the sim's autostopper uses
+// over the top and bottom unignored plays.
+func tiebreakByEquity(optimalWinProb, playedWinProb float64) bool {
+	if optimalWinProb < blowoutWinProbThreshold {
+		return true
+	}
+	return optimalWinProb > 1-blowoutWinProbThreshold &&
+		playedWinProb > 1-blowoutWinProbThreshold
 }
 
 // extractTopSimPlays returns at most maxTop plays plus ensuring the played move is included.

--- a/gameanalysis/analyzer.go
+++ b/gameanalysis/analyzer.go
@@ -226,10 +226,23 @@ func (a *Analyzer) AnalyzeSingleTurn(ctx context.Context, history *pb.GameHistor
 		return nil, err
 	}
 
-	// Categorize the mistake (authoritative call — runs after all flags are set)
-	analysis.MistakeCategory = categorizeMistake(analysis)
+	// Grade the turn (authoritative call — runs after all flags are set)
+	finalizeGrade(analysis)
 
 	return analysis, nil
+}
+
+// finalizeGrade records the mistake category and, from it, whether the play was
+// optimal. Up to this point WasOptimal means "is the move the engine picked",
+// which each phase analyzer needs while it works out what the play cost. That
+// is too strict as a verdict: an endgame can have several moves sharing the
+// best final spread, and a sim cannot separate plays whose win probabilities
+// sit inside its own noise. Both cases come out of categorizeMistake as "cost
+// nothing", so a turn is optimal exactly when it has no mistake to report --
+// which also means every turn in a game is either optimal or categorized.
+func finalizeGrade(analysis *TurnAnalysis) {
+	analysis.MistakeCategory = categorizeMistake(analysis)
+	analysis.WasOptimal = analysis.MistakeCategory == ""
 }
 
 // AnalyzeGame analyzes every move in a game and returns the results

--- a/gameanalysis/analyzer_test.go
+++ b/gameanalysis/analyzer_test.go
@@ -105,6 +105,63 @@ func TestDeterminePhase(t *testing.T) {
 	}
 }
 
+func TestTiebreakByEquity(t *testing.T) {
+	tests := []struct {
+		name                          string
+		optimalWinProb, playedWinProb float64
+		expected                      bool
+	}{
+		{"ordinary position", 0.62, 0.55, false},
+		// The whole field is hopeless: the optimal play is the maximum, so
+		// nothing else can be above it either.
+		{"optimal hopeless", 0.001, 0.0, true},
+		{"both locked up", 0.9999, 0.999, true},
+		// Reported in #503: the best play is a lock but the played move still
+		// loses 15.8% of the time, which is a real win% difference.
+		{"only optimal locked up", 0.9999, 0.842, false},
+		{"just inside threshold", 0.9999, 0.9949, false},
+	}
+
+	for _, tt := range tests {
+		got := tiebreakByEquity(tt.optimalWinProb, tt.playedWinProb)
+		if got != tt.expected {
+			t.Errorf("%s: tiebreakByEquity(%v, %v) = %v, expected %v",
+				tt.name, tt.optimalWinProb, tt.playedWinProb, got, tt.expected)
+		}
+	}
+}
+
+// TestCategorizeMistake_SaturatedTopPlay covers the position from #503: B1 COD
+// sims at 100% with +3.1 equity, the played B2 ODIC at 84.2% with -11.4. The
+// equity tiebreak must stay off, so the 15.8% win probability loss grades as
+// Large rather than the 14.5-point equity gap grading as Medium.
+func TestCategorizeMistake_SaturatedTopPlay(t *testing.T) {
+	const optimalWinProb, playedWinProb = 0.9999, 0.842
+	const optimalEquity, playedEquity = 3.1, -11.4
+
+	analysis := &TurnAnalysis{
+		Phase:          PhaseEarlyPreEndgame,
+		OptimalWinProb: optimalWinProb,
+		PlayedWinProb:  playedWinProb,
+		WinProbLoss:    optimalWinProb - playedWinProb,
+		WasOptimal:     false,
+	}
+
+	// Mirrors what analyzeWithSim does once the sim finishes.
+	if tiebreakByEquity(analysis.OptimalWinProb, analysis.PlayedWinProb) {
+		if equityDiff := optimalEquity - playedEquity; equityDiff > 0.5 {
+			analysis.SpreadLoss = int16(equityDiff + 0.5)
+		}
+	}
+
+	if analysis.SpreadLoss != 0 {
+		t.Errorf("expected no equity tiebreak, got SpreadLoss=%d", analysis.SpreadLoss)
+	}
+	if got := categorizeMistake(analysis); got != "Large" {
+		t.Errorf("expected Large, got %q", got)
+	}
+}
+
 func TestAnalyzeGame_NilHistory(t *testing.T) {
 	cfg := &config.Config{}
 	analyzer := New(cfg, DefaultAnalysisConfig(), "")

--- a/gameanalysis/analyzer_test.go
+++ b/gameanalysis/analyzer_test.go
@@ -29,8 +29,8 @@ func TestAnalyzerCreation(t *testing.T) {
 func TestDefaultAnalysisConfig(t *testing.T) {
 	cfg := DefaultAnalysisConfig()
 
-	if cfg.SimPlaysEarlyMid != 40 {
-		t.Errorf("expected SimPlaysEarlyMid=40, got %d", cfg.SimPlaysEarlyMid)
+	if cfg.SimPlaysEarlyMid != 100 {
+		t.Errorf("expected SimPlaysEarlyMid=100, got %d", cfg.SimPlaysEarlyMid)
 	}
 
 	if cfg.SimPliesEarlyMid != 5 {
@@ -41,8 +41,8 @@ func TestDefaultAnalysisConfig(t *testing.T) {
 		t.Errorf("expected SimStopEarlyMid=99, got %d", cfg.SimStopEarlyMid)
 	}
 
-	if cfg.SimPlaysEarlyPreEndgame != 80 {
-		t.Errorf("expected SimPlaysEarlyPreEndgame=80, got %d", cfg.SimPlaysEarlyPreEndgame)
+	if cfg.SimPlaysEarlyPreEndgame != 100 {
+		t.Errorf("expected SimPlaysEarlyPreEndgame=100, got %d", cfg.SimPlaysEarlyPreEndgame)
 	}
 
 	if cfg.SimPliesEarlyPreEndgame != 10 {

--- a/gameanalysis/analyzer_test.go
+++ b/gameanalysis/analyzer_test.go
@@ -162,6 +162,74 @@ func TestCategorizeMistake_SaturatedTopPlay(t *testing.T) {
 	}
 }
 
+// TestFinalizeGrade covers #454: a play that ties the engine's move costs
+// nothing and is optimal, even though it is a different move.
+func TestFinalizeGrade(t *testing.T) {
+	tests := []struct {
+		name             string
+		analysis         TurnAnalysis
+		expectedOptimal  bool
+		expectedCategory string
+	}{
+		{
+			name:            "played the engine's move",
+			analysis:        TurnAnalysis{Phase: PhaseEarlyMid, WasOptimal: true},
+			expectedOptimal: true,
+		},
+		{
+			// Several endgame moves can share the best final spread; the solver
+			// proved they are worth the same, so a different move is still optimal.
+			name:            "endgame ties the best final spread",
+			analysis:        TurnAnalysis{Phase: PhaseEndgame, SpreadLoss: 0},
+			expectedOptimal: true,
+		},
+		{
+			name: "endgame gives up spread",
+			analysis: TurnAnalysis{Phase: PhaseEndgame, SpreadLoss: 3,
+				OptimalFinalSpread: 20, CurrentSpread: 50}, // still winning, so not blown
+			expectedOptimal:  false,
+			expectedCategory: "Small",
+		},
+		{
+			// Below the noise threshold the sim cannot tell the plays apart.
+			name:            "sim loss within noise",
+			analysis:        TurnAnalysis{Phase: PhaseEarlyPreEndgame, WinProbLoss: 0.001},
+			expectedOptimal: true,
+		},
+		{
+			name:             "sim loss above noise",
+			analysis:         TurnAnalysis{Phase: PhaseEarlyPreEndgame, WinProbLoss: 0.004},
+			expectedOptimal:  false,
+			expectedCategory: "Small",
+		},
+		{
+			// Tied on win%, but the equity tiebreak separates them.
+			name:             "tied win% but loses spread",
+			analysis:         TurnAnalysis{Phase: PhasePreEndgame, WinProbLoss: 0, SpreadLoss: 9},
+			expectedOptimal:  false,
+			expectedCategory: "Medium",
+		},
+	}
+
+	for _, tt := range tests {
+		analysis := tt.analysis
+		finalizeGrade(&analysis)
+
+		if analysis.WasOptimal != tt.expectedOptimal {
+			t.Errorf("%s: WasOptimal = %v, expected %v", tt.name, analysis.WasOptimal, tt.expectedOptimal)
+		}
+		if analysis.MistakeCategory != tt.expectedCategory {
+			t.Errorf("%s: MistakeCategory = %q, expected %q",
+				tt.name, analysis.MistakeCategory, tt.expectedCategory)
+		}
+		// Every turn is either optimal or carries a category, never both or neither.
+		if analysis.WasOptimal == (analysis.MistakeCategory != "") {
+			t.Errorf("%s: optimal=%v and category=%q disagree",
+				tt.name, analysis.WasOptimal, analysis.MistakeCategory)
+		}
+	}
+}
+
 func TestAnalyzeGame_NilHistory(t *testing.T) {
 	cfg := &config.Config{}
 	analyzer := New(cfg, DefaultAnalysisConfig(), "")

--- a/gameanalysis/results.go
+++ b/gameanalysis/results.go
@@ -122,7 +122,10 @@ type TurnAnalysis struct {
 	OptimalFinalSpread int16 // The final spread with the optimal move (endgame only)
 	CurrentSpread      int   // The spread before this move (endgame only, for blown endgame detection)
 
-	// Whether the played move was optimal
+	// Whether the played move cost nothing measurable: either it is the move
+	// the engine picked, or it ties that move. Several plays can share the best
+	// final spread in an endgame, and a sim can't separate plays whose win
+	// probabilities are within its own noise, so this is not move identity.
 	WasOptimal bool
 
 	// Mistake categorization

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -66,6 +66,33 @@ const MaxHeatMapIterations = 7500
 // negligibly higher win probability.
 const winPctSortEpsilon = 1e-9
 
+// winProbsIndistinguishable reports whether two win probabilities are too close,
+// or too saturated, to rank plays by.
+//
+// Differences below winPctSortEpsilon are floating-point noise. Past that, once
+// both plays are certain wins (or both certain losses) the game is decided and
+// all that is left of the win probability is sampling jitter in its last few
+// decimal places. Win probability per iteration is a table lookup on the final
+// spread rather than a win/loss count, so a pair of certain wins lands on values
+// like 0.999999999 and 0.999999989 -- a meaningless gap, but ten times
+// winPctSortEpsilon, enough to sort a play with eight fewer points of equity on
+// top. This is the same regime the autostopper calls decided, where it already
+// ranks and prunes by equity, so ranking by equity here keeps the final results
+// in agreement with the stopping logic that produced them.
+//
+// Comparing against a fixed threshold keeps the ordering strict and weak: plays
+// fall into certain-win, contested, and certain-loss groups; every group beats
+// the next on win probability alone, and the two saturated groups order their
+// own members by equity.
+func winProbsIndistinguishable(wi, wj float64) bool {
+	if math.Abs(wi-wj) <= winPctSortEpsilon {
+		return true
+	}
+	bothWon := wi > 1-defaultMinReasonableWProb && wj > 1-defaultMinReasonableWProb
+	bothLost := wi < defaultMinReasonableWProb && wj < defaultMinReasonableWProb
+	return bothWon || bothLost
+}
+
 type InferenceMode int
 
 const (
@@ -973,7 +1000,7 @@ func (s *Simmer) sortPlaysByWinRate(ignoredAtBottom bool) {
 		sort.Slice(plays, func(i, j int) bool {
 			a, b := plays[i], plays[j]
 			wi, wj := a.winPctStats.Mean(), b.winPctStats.Mean()
-			if math.Abs(wi-wj) > winPctSortEpsilon {
+			if !winProbsIndistinguishable(wi, wj) {
 				return wi > wj
 			}
 			return a.equityStats.Mean() > b.equityStats.Mean()

--- a/montecarlo/sort_plays_test.go
+++ b/montecarlo/sort_plays_test.go
@@ -1,0 +1,148 @@
+package montecarlo
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// namedPlay describes a simmed play for the sorting tests. Pushing a single
+// value into a Statistic makes Mean() return it exactly, which matters here:
+// the win probabilities being ordered differ in their eighth decimal place.
+type namedPlay struct {
+	name    string
+	winProb float64
+	equity  float64
+	ignored bool
+}
+
+func sortNamedPlays(plays []namedPlay, ignoredAtBottom bool) []string {
+	names := map[*SimmedPlay]string{}
+	simmed := make([]*SimmedPlay, len(plays))
+	for i, p := range plays {
+		sp := &SimmedPlay{}
+		sp.winPctStats.Push(p.winProb)
+		sp.equityStats.Push(p.equity)
+		if p.ignored {
+			sp.Ignore()
+		}
+		names[sp] = p.name
+		simmed[i] = sp
+	}
+
+	s := &Simmer{simmedPlays: &SimmedPlays{plays: simmed}}
+	s.sortPlaysByWinRate(ignoredAtBottom)
+
+	sorted := make([]string, len(simmed))
+	for i, sp := range s.simmedPlays.plays {
+		sorted[i] = names[sp]
+	}
+	return sorted
+}
+
+// turn19Plays is the simmed field from woogles game PewhwF3WGB turn 19, the
+// position reported in #502. Every play is a certain win -- they differ only
+// from the eighth decimal place on -- while their equities span 8.6 points.
+var turn19Plays = []namedPlay{
+	{name: "L11 RETAX", winProb: 0.9999999996191397, equity: 8.704273079829118},
+	{name: "N1 AY", winProb: 0.9999999894255265, equity: 17.31290228184371},
+	{name: "3G A.YE", winProb: 0.9999999881373213, equity: 11.93},
+	{name: "1M .AX", winProb: 0.9999999858521573, equity: 12.37},
+	{name: "1M .YX", winProb: 0.99999993771813, equity: 14.12},
+}
+
+// TestSortPlaysByWinRate_DecidedRanksByEquity covers #502: the analyzer took
+// the head of this list as the optimal play and so called the played RETAX
+// optimal, docking nothing for the 8.6 points of equity it gave up.
+func TestSortPlaysByWinRate_DecidedRanksByEquity(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(sortNamedPlays(turn19Plays, true), []string{
+		"N1 AY",     // 17.31
+		"1M .YX",    // 14.12
+		"1M .AX",    // 12.37
+		"3G A.YE",   // 11.93
+		"L11 RETAX", // 8.70
+	})
+}
+
+// TestSortPlaysByWinRate_ContestedRanksByWinProb guards the other direction:
+// while the game is still in doubt, win probability outranks equity no matter
+// how wide the equity gap is.
+func TestSortPlaysByWinRate_ContestedRanksByWinProb(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(sortNamedPlays([]namedPlay{
+		{name: "low win, high equity", winProb: 0.51, equity: 40},
+		{name: "high win, low equity", winProb: 0.62, equity: -10},
+		{name: "mid win, mid equity", winProb: 0.55, equity: 12},
+	}, true), []string{
+		"high win, low equity",
+		"mid win, mid equity",
+		"low win, high equity",
+	})
+}
+
+// TestSortPlaysByWinRate_SaturatedGroupsStayOrdered checks that switching to
+// equity inside the saturated groups doesn't let a certain loss climb over a
+// contested play, or a contested play over a certain win.
+func TestSortPlaysByWinRate_SaturatedGroupsStayOrdered(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(sortNamedPlays([]namedPlay{
+		{name: "certain loss, huge equity", winProb: 0.0001, equity: 90},
+		{name: "contested, no equity", winProb: 0.5, equity: -30},
+		{name: "certain win, low equity", winProb: 0.9999, equity: 1},
+		{name: "certain win, high equity", winProb: 0.99989, equity: 20},
+		{name: "certain loss, less equity", winProb: 0.0002, equity: 10},
+	}, true), []string{
+		"certain win, high equity",
+		"certain win, low equity",
+		"contested, no equity",
+		"certain loss, huge equity",
+		"certain loss, less equity",
+	})
+}
+
+// TestSortPlaysByWinRate_IgnoredStayAtBottom checks that pruned plays are still
+// parked below the live ones, sorted among themselves.
+func TestSortPlaysByWinRate_IgnoredStayAtBottom(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(sortNamedPlays([]namedPlay{
+		{name: "pruned, best equity", winProb: 0.9999999999, equity: 30, ignored: true},
+		{name: "live, worst equity", winProb: 0.9999999998, equity: 2},
+		{name: "pruned, worse equity", winProb: 0.9999999997, equity: 20, ignored: true},
+		{name: "live, best equity", winProb: 0.9999999996, equity: 5},
+	}, true), []string{
+		"live, best equity",
+		"live, worst equity",
+		"pruned, best equity",
+		"pruned, worse equity",
+	})
+}
+
+func TestWinProbsIndistinguishable(t *testing.T) {
+	tests := []struct {
+		name     string
+		wi, wj   float64
+		expected bool
+	}{
+		{"contested", 0.62, 0.55, false},
+		{"float noise", 0.62, 0.62 + 1e-10, true},
+		// #502: ten times winPctSortEpsilon apart, both certain wins.
+		{"both certain wins", 0.9999999996191397, 0.9999999894255265, true},
+		{"both certain losses", 0.0001, 0.004, true},
+		{"certain win vs contested", 0.9999, 0.9, false},
+		{"certain loss vs contested", 0.001, 0.4, false},
+		{"straddling the win threshold", 0.9951, 0.9949, false},
+	}
+
+	for _, tt := range tests {
+		got := winProbsIndistinguishable(tt.wi, tt.wj)
+		if got != tt.expected {
+			t.Errorf("%s: winProbsIndistinguishable(%v, %v) = %v, expected %v",
+				tt.name, tt.wi, tt.wj, got, tt.expected)
+		}
+	}
+}

--- a/shell/analyze.go
+++ b/shell/analyze.go
@@ -138,13 +138,17 @@ func (sc *ShellController) formatAnalysisResults(result *gameanalysis.GameAnalys
 	sb.WriteString("      Medium = 8-15 pts spread = 0.5 pts\n")
 	sb.WriteString("      Large  = 16+ pts spread = 1.0 pts\n")
 	sb.WriteString("      Exception: Blown endgame (win→tie/loss) = Large regardless of spread\n")
+	sb.WriteString("      Losses of ≤0.25% win are within sim noise and are not mistakes\n")
 	sb.WriteString("  Mistake Index = Sum of mistake points for all turns\n")
+	sb.WriteString("  Optimal = Turns that cost nothing measurable, so every turn is either\n")
+	sb.WriteString("            optimal or has a mistake category\n")
 	sb.WriteString("\n")
 	sb.WriteString("  Diff Format:\n")
 	sb.WriteString("    PEG with tied win%: Shows \"0.0% (+N)\" where N is spread difference\n")
 	sb.WriteString("    Endgame: Shows spread difference in points\n")
 	sb.WriteString("    Other phases: Shows win probability loss as percentage\n")
 	sb.WriteString("\n")
+	sb.WriteString("  Tie = Optimal by a different move than the one shown (equal value)\n")
 	sb.WriteString("  ⚠️ Phony = Played unchallenged phony\n")
 	sb.WriteString("  ❌ Missed challenge = Failed to challenge opponent's phony\n")
 	sb.WriteString("  💥 Blown endgame = Mistake changed winning position to loss/tie\n")
@@ -184,6 +188,10 @@ func formatTurnTable(result *gameanalysis.GameAnalysisResult) string {
 		} else {
 			optimal = turn.OptimalMoveStr
 		}
+		// A turn can be optimal without being the engine's move, by tying it.
+		// Say so, or the row reads as though the two columns disagree.
+		tiedBest := turn.WasOptimal && played != optimal
+
 		if len([]rune(played)) > 22 {
 			played = string([]rune(played)[:22])
 		}
@@ -191,7 +199,7 @@ func formatTurnTable(result *gameanalysis.GameAnalysisResult) string {
 			optimal = string([]rune(optimal)[:22])
 		}
 
-		diff := formatDiff(turn.Phase == gameanalysis.PhaseEndgame, turn.WasOptimal, turn.WinProbLoss, int(turn.SpreadLoss))
+		diff := formatDiff(turn.Phase == gameanalysis.PhaseEndgame, turn.WinProbLoss, int(turn.SpreadLoss))
 
 		phaseDisplay := turn.Phase.String()
 		if turn.Phase == gameanalysis.PhaseEarlyMid && turn.TilesInBag <= 50 {
@@ -204,6 +212,9 @@ func formatTurnTable(result *gameanalysis.GameAnalysisResult) string {
 		}
 
 		var notes []string
+		if tiedBest {
+			notes = append(notes, "Tie")
+		}
 		if turn.IsPhony {
 			if turn.PhonyChallenged {
 				notes = append(notes, "Phony(off)")
@@ -358,7 +369,11 @@ func formatSingleTurnAnalysis(turn *gameanalysis.TurnAnalysis) string {
 
 	// Analysis metrics
 	if turn.WasOptimal {
-		sb.WriteString("✓ Optimal play!\n")
+		if turn.PlayedMove.ShortDescription() != turn.OptimalMove.ShortDescription() {
+			sb.WriteString("✓ Optimal play! (ties the move above)\n")
+		} else {
+			sb.WriteString("✓ Optimal play!\n")
+		}
 	} else {
 		if turn.Phase == gameanalysis.PhaseEndgame {
 			sb.WriteString(fmt.Sprintf("Spread Loss: %d points\n", turn.SpreadLoss))
@@ -417,21 +432,18 @@ func formatSingleTurnAnalysis(turn *gameanalysis.TurnAnalysis) string {
 
 // formatDiff formats the equity/win-probability difference for a turn.
 // isEndgame: true if the turn is in the endgame phase.
-// wasOptimal: true if the played move was optimal.
 // winProbLoss: fractional win-probability difference (0–1).
 // spreadLoss: equity/spread loss when win probs are effectively tied.
-func formatDiff(isEndgame, wasOptimal bool, winProbLoss float64, spreadLoss int) string {
+//
+// What is printed is always what was measured, including the sub-threshold
+// losses that still count as optimal — a play the analyzer scores as optimal
+// should not have to render as an exact zero to look like one.
+func formatDiff(isEndgame bool, winProbLoss float64, spreadLoss int) string {
 	if isEndgame {
-		if wasOptimal {
-			return "+0"
-		}
 		return fmt.Sprintf("%+d", spreadLoss)
 	}
-	if !wasOptimal && spreadLoss > 0 {
+	if spreadLoss > 0 {
 		return fmt.Sprintf("%.1f%% (%+d)", winProbLoss*100, spreadLoss)
-	}
-	if wasOptimal {
-		return "0.0%"
 	}
 	return fmt.Sprintf("%.1f%%", winProbLoss*100)
 }

--- a/shell/analyze_batch.go
+++ b/shell/analyze_batch.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -21,12 +23,12 @@ import (
 
 // GameSource represents a source for loading a game
 type GameSource struct {
-	Type       string // "woogles", "xt", "file", "web"
-	Identifier string // game ID or file path
+	Type       string // "woogles", "xt", "file", "dir", "web"
+	Identifier string // game ID, file path, or directory path
 	Original   string // original source string (for display)
 }
 
-// parseGameSource parses a game source string (e.g., "woog:ABC123", "xt:12345", "/path/to/game.gcg", "woogcollection:UUID")
+// parseGameSource parses a game source string (e.g., "woog:ABC123", "xt:12345", "/path/to/game.gcg", "/path/to/games/", "woogcollection:UUID")
 func parseGameSource(source string) (*GameSource, error) {
 	if strings.HasPrefix(source, "woogcollection:") {
 		return &GameSource{
@@ -53,13 +55,40 @@ func parseGameSource(source string) (*GameSource, error) {
 			Original:   source,
 		}, nil
 	} else {
-		// Assume it's a file path
+		// A path, either a single game or a folder of them. A path that can't
+		// be stat'ed is left as a file so the loader reports what went wrong.
+		if info, err := os.Stat(source); err == nil && info.IsDir() {
+			return &GameSource{
+				Type:       "dir",
+				Identifier: source,
+				Original:   source,
+			}, nil
+		}
 		return &GameSource{
 			Type:       "file",
 			Identifier: source,
 			Original:   source,
 		}, nil
 	}
+}
+
+// gcgFilesInDir returns every .gcg file at or below dir, in the order WalkDir
+// visits them, which is lexical within each directory.
+func gcgFilesInDir(dir string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.EqualFold(filepath.Ext(path), ".gcg") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paths, nil
 }
 
 // WooglesCollectionGame represents a game in a collection
@@ -179,8 +208,9 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 			return nil, fmt.Errorf("failed to parse source %s: %w", arg, err)
 		}
 
-		// If it's a collection, expand it into individual game sources
-		if source.Type == "collection" {
+		// Collections and folders stand for many games; expand them.
+		switch source.Type {
+		case "collection":
 			sc.showMessage(fmt.Sprintf("Fetching collection: %s", source.Identifier))
 			gameIDs, err := sc.fetchWooglesCollection(source.Identifier)
 			if err != nil {
@@ -200,9 +230,38 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 					Original:   fmt.Sprintf("woog:%s (from woogcollection:%s)", gameID, source.Identifier),
 				})
 			}
-		} else {
+
+		case "dir":
+			sc.showMessage(fmt.Sprintf("Scanning folder for .gcg files: %s", source.Identifier))
+			paths, err := gcgFilesInDir(source.Identifier)
+			if err != nil {
+				if !continueOnError {
+					return nil, fmt.Errorf("failed to scan folder %s: %w", source.Identifier, err)
+				}
+				sc.showMessage(fmt.Sprintf("  Error scanning folder: %v", err))
+				continue
+			}
+			if len(paths) == 0 {
+				sc.showMessage("  No .gcg files found")
+				continue
+			}
+			sc.showMessage(fmt.Sprintf("  Found %d .gcg files", len(paths)))
+
+			for _, path := range paths {
+				sources = append(sources, &GameSource{
+					Type:       "file",
+					Identifier: path,
+					Original:   path,
+				})
+			}
+
+		default:
 			sources = append(sources, source)
 		}
+	}
+
+	if len(sources) == 0 {
+		return nil, errors.New("no games to analyze")
 	}
 
 	// Create batch result

--- a/shell/analyze_test.go
+++ b/shell/analyze_test.go
@@ -1,0 +1,75 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/domino14/macondo/gameanalysis"
+)
+
+func TestFormatDiff(t *testing.T) {
+	tests := []struct {
+		name        string
+		isEndgame   bool
+		winProbLoss float64
+		spreadLoss  int
+		expected    string
+	}{
+		{name: "no loss", expected: "0.0%"},
+		{name: "win prob loss", winProbLoss: 0.043, expected: "4.3%"},
+		// #454: a loss too small to be a mistake still gets reported as what it
+		// was, rather than rounding into a bare zero.
+		{name: "loss inside the noise threshold", winProbLoss: 0.001, expected: "0.1%"},
+		{name: "spread tiebreak", winProbLoss: 0, spreadLoss: 9, expected: "0.0% (+9)"},
+		{name: "endgame tie", isEndgame: true, expected: "+0"},
+		{name: "endgame loss", isEndgame: true, spreadLoss: 3, expected: "+3"},
+	}
+
+	for _, tt := range tests {
+		got := formatDiff(tt.isEndgame, tt.winProbLoss, tt.spreadLoss)
+		if got != tt.expected {
+			t.Errorf("%s: formatDiff(%v, %v, %v) = %q, expected %q",
+				tt.name, tt.isEndgame, tt.winProbLoss, tt.spreadLoss, got, tt.expected)
+		}
+	}
+}
+
+// TestFormatTurnTable_TieNote checks that a turn that is optimal by a move
+// other than the one in the Optimal column says so, since the row would
+// otherwise read as though the two columns contradict each other.
+func TestFormatTurnTable_TieNote(t *testing.T) {
+	result := &gameanalysis.GameAnalysisResult{
+		Turns: []*gameanalysis.TurnAnalysis{
+			{
+				TurnNumber: 20, PlayerName: "porch_microwave", Rack: "FIJKLNU",
+				PlayedMoveStr: "13K J.NK", OptimalMoveStr: "14G F.LK",
+				Phase: gameanalysis.PhaseEarlyPreEndgame, TilesInBag: 5,
+				WinProbLoss: 0.0004, WasOptimal: true,
+			},
+			{
+				TurnNumber: 18, PlayerName: "porch_microwave", Rack: "AEIMMRT",
+				PlayedMoveStr: "1I MARMiTE", OptimalMoveStr: "1I MARMiTE",
+				Phase: gameanalysis.PhaseEarlyMid, TilesInBag: 20,
+				WasOptimal: true,
+			},
+		},
+	}
+
+	lines := strings.Split(strings.TrimSpace(formatTurnTable(result)), "\n")
+	var tied, same string
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "20 "):
+			tied = line
+		case strings.HasPrefix(line, "18 "):
+			same = line
+		}
+	}
+
+	if !strings.Contains(tied, "Tie") {
+		t.Errorf("expected a Tie note on the turn won by a different move, got %q", tied)
+	}
+	if strings.Contains(same, "Tie") {
+		t.Errorf("did not expect a Tie note when the moves match, got %q", same)
+	}
+}

--- a/shell/analyze_test.go
+++ b/shell/analyze_test.go
@@ -1,11 +1,97 @@
 package shell
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/domino14/macondo/gameanalysis"
 )
+
+// TestParseGameSource_Folder covers #508: a path is a folder source when it is
+// one on disk, and a file source otherwise.
+func TestParseGameSource_Folder(t *testing.T) {
+	dir := t.TempDir()
+	gcg := filepath.Join(dir, "game.gcg")
+	if err := os.WriteFile(gcg, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		source       string
+		expectedType string
+	}{
+		{dir, "dir"},
+		{gcg, "file"},
+		{filepath.Join(dir, "nonexistent.gcg"), "file"}, // let the loader report it
+		{"woog:ABC123", "woogles"},
+		{"xt:12345", "xt"},
+		{"woogcollection:UUID", "collection"},
+		{"https://example.com/game.gcg", "web"},
+	}
+
+	for _, tt := range tests {
+		got, err := parseGameSource(tt.source)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", tt.source, err)
+			continue
+		}
+		if got.Type != tt.expectedType {
+			t.Errorf("%s: type = %q, expected %q", tt.source, got.Type, tt.expectedType)
+		}
+	}
+}
+
+func TestGCGFilesInDir(t *testing.T) {
+	dir := t.TempDir()
+	write := func(parts ...string) string {
+		path := filepath.Join(append([]string{dir}, parts...)...)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	// Written out of order to check the walk sorts them.
+	second := write("b.gcg")
+	first := write("a.gcg")
+	nested := write("round2", "c.gcg")
+	upper := write("round2", "d.GCG") // extension match is case-insensitive
+	write("notes.txt")
+	write("game.gcg.bak")
+
+	paths, err := gcgFilesInDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{first, second, nested, upper}
+	if len(paths) != len(expected) {
+		t.Fatalf("got %d files %v, expected %d %v", len(paths), paths, len(expected), expected)
+	}
+	for i, path := range paths {
+		if path != expected[i] {
+			t.Errorf("file %d = %q, expected %q", i, path, expected[i])
+		}
+	}
+
+	// An empty folder is not an error; the caller reports it.
+	empty, err := gcgFilesInDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error on empty dir: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected no files in an empty dir, got %v", empty)
+	}
+
+	if _, err := gcgFilesInDir(filepath.Join(dir, "nope")); err == nil {
+		t.Error("expected an error for a missing folder")
+	}
+}
 
 func TestFormatDiff(t *testing.T) {
 	tests := []struct {

--- a/shell/helptext/analyze-batch.txt
+++ b/shell/helptext/analyze-batch.txt
@@ -4,6 +4,7 @@ Example:
     analyze-batch woog:ABC123 woog:DEF456
     analyze-batch xt:12345 xt:67890
     analyze-batch /path/to/game1.gcg /path/to/game2.gcg
+    analyze-batch /path/to/gcgs
     analyze-batch woog:ABC xt:123 /path/game.gcg
     analyze-batch -player "nickname" woog:ABC woog:DEF
     analyze-batch -summary-only woog:ABC woog:DEF
@@ -25,6 +26,10 @@ It supports loading games from:
   - Woogles Collection: Use format "woogcollection:UUID" (fetches all games in collection)
   - Cross-tables: Use format "xt:GAMEID"
   - Local GCG files: Use file path (e.g., "/path/to/game.gcg")
+  - Folders of GCG files: Use a directory path (e.g., "/path/to/gcgs"). The
+    folder is searched recursively and every .gcg file found is analyzed, in
+    alphabetical order. Each file is stored under its own path, so re-running
+    the command skips the ones already analyzed unless -force is given.
   - Web URLs: Use full HTTP/HTTPS URL
 
 Each game is analyzed using the same phase-appropriate analysis as the `analyze`

--- a/shell/helptext/analyze.txt
+++ b/shell/helptext/analyze.txt
@@ -21,7 +21,9 @@ The analysis shows:
   - Per-player accuracy statistics
 
 Note: This command requires a game to be loaded. Use `load` to load a GCG file
-or `load woogles <game-id>` to load a game from Woogles.
+or `load woogles <game-id>` to load a game from Woogles. To analyze many games
+at once without loading each one, use `analyze-batch`, which also accepts a
+folder and analyzes every .gcg file in it.
 
 When a game was loaded from a known source (Woogles, cross-tables, a file
 path, or a web URL), the analysis is automatically saved to the local store

--- a/shell/helptext/usage-standard.txt
+++ b/shell/helptext/usage-standard.txt
@@ -35,7 +35,7 @@ Examining a game:
     challenge [n] - add a challenge bonus to the last play of n points, or challenge play off.
     analyze [options] - analyze all moves in the loaded game
     analyze-turn - analyze the current turn
-    analyze-batch [options] <source> [source ...] - analyze multiple games
+    analyze-batch [options] <source> [source ...] - analyze multiple games, or a folder of .gcg files
     analyze-browse [options] - list/browse/delete stored analyses
     analyze-view <name> [name ...] - view a stored analysis
 Other:


### PR DESCRIPTION
A run of analyzer fixes, plus one new source type for `analyze-batch`.

Fixes #503, fixes #502, fixes #454, fixes #508.

### Consider 100 plays in the early/mid and early pre-endgame sims

The analyzer simmed the top 40 static plays with more than 7 tiles in the bag and the top 80 with 2-7 left; the elite bot used the same 40/80 split keyed on unseen tiles. Both are now 100, so the sim ranks a candidate set that leans less on the static evaluator getting the ordering right. This costs roughly linear wall-clock per turn in both the analyzer and the bot.

### #503: only fall back to equity when both compared plays are saturated

After a sim the analyzer decides whether win% can separate the optimal and played moves, falling back to equity when it can't. That test looked only at the optimal play, which is the maximum of the field: a near-zero win prob there does mean every play is hopeless, but a near-one win prob says nothing about the rest of the field.

In the reported position the best play was 100% and the played move 84.2%. The 14.5-point equity gap rounded to 15, landing exactly on the Medium spread boundary, so a 15.8% win probability blunder scored 0.5 mistake points instead of 1.0 — which also flows into the mistake index and the ELO estimate.

The played move now has to be saturated too, the same conjunction the sim's autostopper applies over its top and bottom unignored plays.

### #502: rank decided positions by equity instead of win probability noise

Plays were sorted by win probability, reaching equity only within `winPctSortEpsilon` (1e-9). That epsilon is sized for floating point noise, but win probability per iteration is a table lookup on the final spread rather than a win/loss count, so saturated plays land on distinct values many times 1e-9 apart while being equally certain wins.

Game `PewhwF3WGB` turn 19, all five plays over 5321 iterations:

```
L11 RETAX  win 0.9999999996191397  equity  8.70
N1  AY     win 0.9999999894255265  equity 17.31
3G  A.YE   win 0.9999999881373213  equity 11.93
1M  .AX    win 0.9999999858521573  equity 12.37
1M  .YX    win 0.9999999377181300  equity 14.12
```

RETAX led AY by 1.02e-8 — ten times the epsilon, between two plays that each win over 99.999998% of the time — so it sorted first, the analyzer took the head of the list as optimal, and the played RETAX came back marked optimal with its 8.61 points of forgone equity never docked.

The autostopper had already reached the opposite conclusion on that same sim: with the top and bottom plays both certain wins it switches to ranking and pruning by equity, and RETAX only survived because the analyzer pins the played move as unignorable. `WinningPlay()` shares this sort, so the elite bot was picking among certain wins by the same noise rather than by spread.

Win probabilities are now treated as indistinguishable when both plays are certain wins or both certain losses, using the threshold the autostopper already calls decided. Plays fall into certain-win, contested and certain-loss groups; each group still beats the next on win probability, and the saturated groups order their own members by equity.

### #454: count plays that tie the best move as optimal

`WasOptimal` meant "is the move the engine picked", so a play that cost nothing still counted against the optimal tally: an endgame can have several moves sharing the best final spread, and a sim cannot separate plays whose win probabilities sit inside its own noise. The reported game showed five turns at 0.0% loss but only 4/11 optimal.

The verdict is now decided once, where the mistake category is assigned: a turn is optimal exactly when it has no mistake to report, so `Turns = Optimal + Small + Medium + Large`.

The turn table used to print a hardcoded `0.0%` for an optimal play and round everything else to one decimal, which is how that fifth turn read as a flat zero while not counting — its loss was under 0.05%. It now always prints what was measured, and turns that are optimal by a move other than the one in the Optimal column get a `Tie` note.

Note for the UI: the Woogles analyzer labels its badge off the mistake category, so it has always called these turns optimal, while gating the compact `Best` line in the turn header on `was_optimal`. Those now agree, and the only visible change on a tie turn is that the `Best` line stops rendering — it used to appear claiming a `-0.0%` loss. The sim, PEG and endgame tables below it are not gated on `was_optimal`, so the engine's play is still listed there. If the `Best` line is wanted on ties, gating it on `playedMove !== optimalMove` would bring it back; that's a liwords-side change.

### #508: accept a folder of .gcg files as an analyze-batch source

Analyzing a tournament or club night meant listing every game file. A source that is a directory now expands, the way a `woogcollection:` source already does, into one file source per `.gcg` found at or below it. Each file is stored under its own path, so a second run over the same folder skips what was already analyzed unless `-force` is given.

## Testing

New unit tests for each fix, including the exact production values from `PewhwF3WGB` turn 19. For both analyzer fixes I confirmed the tests fail against the previous rule and reproduce the reported symptom exactly. The folder source was also driven through the real shell over a nested directory.

`gameanalysis`, `shell`, `montecarlo` and `ai/bot` pass locally; leaving the full sweep to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
