### PR TITLE
Keep the built WMP when it can't be saved, and save it atomically

### DIFF
--- a/wmp/cache.go
+++ b/wmp/cache.go
@@ -17,13 +17,25 @@ import (
 	"github.com/domino14/word-golib/tilemapping"
 )
 
-// ensureMu serializes concurrent EnsureWMP calls so that only one goroutine
-// attempts to build and write the WMP file for a given lexicon at a time.
-// After the file is on disk the global object cache handles deduplication, so
-// this mutex is only contended during the (rare) initial build.
+// ensureMu serializes the check-build-write sequence in EnsureWMP so that
+// concurrent callers (e.g. autoplay goroutines) don't all race to build the
+// same lexicon. It also guards builtWMPs.
 var ensureMu sync.Mutex
 
+// builtWMPs memoizes WMPs built by EnsureWMP, keyed by .wmp path. Built
+// WMPs can't go into word-golib's global object cache: that cache only
+// populates itself through a load function which it calls with its own
+// non-reentrant mutex held, and building needs kwg.GetKWG and
+// tilemapping.ProbableLetterDistribution, both of which take that same
+// mutex. Building inside a load function deadlocks. So the build happens
+// out here and the result is memoized here.
+var builtWMPs = map[string]*WMP{}
+
 const CacheKeyPrefixWMP = "wmp:"
+
+func wmpPathFor(cfg *wglconfig.Config, name string) string {
+	return filepath.Join(cfg.DataPath, "lexica", name+".wmp")
+}
 
 // CacheLoadFuncWMP loads a WMP for the given lexicon key from disk.
 // It does NOT build the WMP if the file is absent — callers that want
@@ -32,7 +44,7 @@ const CacheKeyPrefixWMP = "wmp:"
 // that writes the file to disk will succeed on the next GetWMP call.
 func CacheLoadFuncWMP(cfg *wglconfig.Config, key string) (interface{}, error) {
 	name := strings.TrimPrefix(key, CacheKeyPrefixWMP)
-	wmpPath := filepath.Join(cfg.DataPath, "lexica", name+".wmp")
+	wmpPath := wmpPathFor(cfg, name)
 	if _, err := os.Stat(wmpPath); err != nil {
 		return nil, fmt.Errorf("WMP file not found for %s at %s", name, wmpPath)
 	}
@@ -55,50 +67,58 @@ func GetWMP(cfg *wglconfig.Config, name string) (*WMP, error) {
 	return w, nil
 }
 
-// EnsureWMP ensures the WMP for the named lexicon is on disk and in the
-// global cache. If the .wmp file is already present, EnsureWMP is equivalent
-// to GetWMP. If not, it builds the WMP from the KWG (which may take several
-// minutes for large lexicons), saves it to disk, and caches it.
+// EnsureWMP returns the WMP for the named lexicon, building it from the KWG
+// when the .wmp file is not on disk. A built WMP is saved for next time if
+// the lexica directory is writable; if it isn't (a read-only data mount, for
+// instance), the WMP is still returned and memoized, so the build cost is
+// paid once per process instead of once per call.
 //
-// This is an interactive / setup operation and should only be called from
-// paths where the user is willing to wait (e.g. shell "set lexicon" or
-// "load" commands). Automated / test paths should use GetWMP (or
-// TryLoadWMP) so they never trigger an unexpectedly long build.
+// Building takes a second or two per lexicon and a few hundred MB of
+// transient memory, so callers on a latency budget should prefer a
+// pre-built .wmp file on disk.
 func EnsureWMP(cfg *wglconfig.Config, name string) (*WMP, error) {
-	wmpPath := filepath.Join(cfg.DataPath, "lexica", name+".wmp")
+	wmpPath := wmpPathFor(cfg, name)
 
-	// Serialize the check-build-write sequence so that concurrent callers
-	// (e.g. autoplay goroutines) don't all race to build the same file.
 	ensureMu.Lock()
-	_, statErr := os.Stat(wmpPath)
-	if statErr != nil {
-		// File not on disk — build from KWG.
-		log.Info().Str("lexicon", name).Msg("WMP not found; building from KWG (this may take a few seconds)...")
-		gd, err := kwg.GetKWG(cfg, name)
-		if err != nil {
-			ensureMu.Unlock()
-			return nil, fmt.Errorf("cannot build WMP for %s: KWG not available: %w", name, err)
-		}
-		ld, err := tilemapping.ProbableLetterDistribution(cfg, name)
-		if err != nil {
-			ensureMu.Unlock()
-			return nil, fmt.Errorf("cannot build WMP for %s: letter distribution unavailable: %w", name, err)
-		}
-		// Use boardDim=15 for standard crossword boards. WMP only supports 15×15 boards.
-		w, buildErr := MakeFromKWG(gd, ld, 15, runtime.NumCPU())
-		if buildErr != nil {
-			ensureMu.Unlock()
-			return nil, fmt.Errorf("WMP build failed for %s: %w", name, buildErr)
-		}
-		if wErr := w.WriteToFile(wmpPath); wErr != nil {
-			log.Warn().Err(wErr).Str("path", wmpPath).
-				Msg("WMP built but could not be saved to disk; it will be rebuilt next session")
-		} else {
-			log.Info().Str("lexicon", name).Str("path", wmpPath).Msg("WMP built and saved")
-		}
-	}
-	ensureMu.Unlock()
+	defer ensureMu.Unlock()
 
-	// File is now on disk (either pre-existing or just written). Load via cache.
-	return GetWMP(cfg, name)
+	if w, ok := builtWMPs[wmpPath]; ok {
+		return w, nil
+	}
+	if _, err := os.Stat(wmpPath); err == nil {
+		// Already on disk; the global object cache dedupes the load.
+		w, err := GetWMP(cfg, name)
+		if err == nil {
+			return w, nil
+		}
+		// The file is there but unreadable — truncated by an interrupted
+		// write, say. Fall through and rebuild rather than failing on it
+		// for the life of the process (and every process after).
+		log.Warn().Err(err).Str("path", wmpPath).Msg("could not load WMP; rebuilding it")
+	}
+
+	log.Info().Str("lexicon", name).Msg("WMP not found; building from KWG (this takes a second or two)...")
+	gd, err := kwg.GetKWG(cfg, name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build WMP for %s: KWG not available: %w", name, err)
+	}
+	ld, err := tilemapping.ProbableLetterDistribution(cfg, name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build WMP for %s: letter distribution unavailable: %w", name, err)
+	}
+	// Use boardDim=15 for standard crossword boards. WMP only supports 15×15 boards.
+	w, err := MakeFromKWG(gd, ld, 15, runtime.NumCPU())
+	if err != nil {
+		return nil, fmt.Errorf("WMP build failed for %s: %w", name, err)
+	}
+	w.Name = name
+
+	if wErr := w.WriteToFile(wmpPath); wErr != nil {
+		log.Warn().Err(wErr).Str("path", wmpPath).
+			Msg("WMP built but could not be saved to disk; using it from memory and rebuilding next session")
+	} else {
+		log.Info().Str("lexicon", name).Str("path", wmpPath).Msg("WMP built and saved")
+	}
+	builtWMPs[wmpPath] = w
+	return w, nil
 }

--- a/wmp/cache_test.go
+++ b/wmp/cache_test.go
@@ -1,0 +1,165 @@
+package wmp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	wglconfig "github.com/domino14/word-golib/config"
+)
+
+// tempFilesIn returns the names of any leftover .wmp-tmp-* files in dir.
+func tempFilesIn(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) failed: %v", dir, err)
+	}
+	var leftovers []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".wmp-tmp-") {
+			leftovers = append(leftovers, e.Name())
+		}
+	}
+	return leftovers
+}
+
+func TestWriteToFileIsReadableAndLeavesNoTempFiles(t *testing.T) {
+	words := stringsToMachineWords([]string{
+		"CAT", "ACT", "TAB", "BAT", "CARE", "RACE", "ACRE",
+	})
+	wmp, err := MakeFromWords(words, testEnglishLD(t), testBoardDim, 1)
+	if err != nil {
+		t.Fatalf("MakeFromWords failed: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "TEST.wmp")
+	if err := wmp.WriteToFile(path); err != nil {
+		t.Fatalf("WriteToFile failed: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat after WriteToFile failed: %v", err)
+	}
+	// Other processes (and other users) read these files; the temp file the
+	// atomic write goes through starts at 0600 and must not stay that way.
+	if perm := fi.Mode().Perm(); perm != 0644 {
+		t.Errorf("WMP file mode = %o, want 644", perm)
+	}
+	if leftovers := tempFilesIn(t, dir); len(leftovers) > 0 {
+		t.Errorf("WriteToFile left temp files behind: %v", leftovers)
+	}
+
+	loaded, err := LoadFromFile("TEST", path)
+	if err != nil {
+		t.Fatalf("LoadFromFile after WriteToFile failed: %v", err)
+	}
+	br := BitRackFromMachineWord(stringsToMachineWords([]string{"CARE"})[0])
+	out := make([]byte, ResultBufferSize)
+	n := loaded.WriteWordsToBuffer(&br, 4, out)
+	got := extractWordsFromBuffer(out[:n], 4)
+	want := []string{"ACRE", "CARE", "RACE"}
+	if !sliceEqual(got, want) {
+		t.Errorf("CARE lookup after WriteToFile: got %v, want %v", got, want)
+	}
+}
+
+// A failed write must not leave a partial .wmp behind: a truncated file
+// would be picked up by every later load (os.Stat succeeds) and fail to
+// parse forever, silently disabling the WMP.
+func TestWriteToFileToUnwritableDirLeavesNothing(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; directory permissions would not be enforced")
+	}
+	words := stringsToMachineWords([]string{"CAT", "ACT", "TAB", "BAT"})
+	wmp, err := MakeFromWords(words, testEnglishLD(t), testBoardDim, 1)
+	if err != nil {
+		t.Fatalf("MakeFromWords failed: %v", err)
+	}
+
+	dir := filepath.Join(t.TempDir(), "readonly")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("Chmod failed: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0755) })
+
+	path := filepath.Join(dir, "TEST.wmp")
+	if err := wmp.WriteToFile(path); err == nil {
+		t.Fatal("WriteToFile to a read-only directory unexpectedly succeeded")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("failed WriteToFile left a file at %s (stat err: %v)", path, err)
+	}
+	if leftovers := tempFilesIn(t, dir); len(leftovers) > 0 {
+		t.Errorf("failed WriteToFile left temp files behind: %v", leftovers)
+	}
+}
+
+// EnsureWMP must still hand back the WMP it just built when the data
+// directory is read-only (e.g. the bot Lambda's EFS mount), and must cache
+// it so the build cost is paid once per process rather than once per call.
+func TestEnsureWMPUsesBuiltWMPWhenSaveFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; directory permissions would not be enforced")
+	}
+	dp := os.Getenv("MACONDO_DATA_PATH")
+	if dp == "" {
+		t.Skip("MACONDO_DATA_PATH not set; skipping WMP build test")
+	}
+	const lexicon = "CSW24"
+	realKWG := filepath.Join(dp, "lexica", "gaddag", lexicon+".kwg")
+	if _, err := os.Stat(realKWG); err != nil {
+		t.Skipf("%s not found at %s", lexicon, realKWG)
+	}
+
+	// A data dir whose lexica/ is read-only, but whose KWG and letter
+	// distributions are the real ones.
+	root := t.TempDir()
+	lexica := filepath.Join(root, "lexica")
+	if err := os.MkdirAll(lexica, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dp, "lexica", "gaddag"), filepath.Join(lexica, "gaddag")); err != nil {
+		t.Fatalf("Symlink gaddag failed: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dp, "letterdistributions"), filepath.Join(root, "letterdistributions")); err != nil {
+		t.Fatalf("Symlink letterdistributions failed: %v", err)
+	}
+	if err := os.Chmod(lexica, 0555); err != nil {
+		t.Fatalf("Chmod failed: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(lexica, 0755) })
+
+	cfg := &wglconfig.Config{DataPath: root}
+	w, err := EnsureWMP(cfg, lexicon)
+	if err != nil {
+		t.Fatalf("EnsureWMP failed even though the built WMP is usable: %v", err)
+	}
+	if w == nil {
+		t.Fatal("EnsureWMP returned a nil WMP")
+	}
+	if w.Name != lexicon {
+		t.Errorf("built WMP Name = %q, want %q", w.Name, lexicon)
+	}
+	if _, err := os.Stat(filepath.Join(lexica, lexicon+".wmp")); !os.IsNotExist(err) {
+		t.Errorf("expected no .wmp file in a read-only dir (stat err: %v)", err)
+	}
+	if leftovers := tempFilesIn(t, lexica); len(leftovers) > 0 {
+		t.Errorf("failed save left temp files behind: %v", leftovers)
+	}
+
+	// Second call must come from the cache rather than rebuilding.
+	w2, err := EnsureWMP(cfg, lexicon)
+	if err != nil {
+		t.Fatalf("second EnsureWMP failed: %v", err)
+	}
+	if w2 != w {
+		t.Error("EnsureWMP rebuilt the WMP instead of returning the cached one")
+	}
+}

--- a/wmp/wmp.go
+++ b/wmp/wmp.go
@@ -12,10 +12,12 @@
 package wmp
 
 import (
+	"bufio"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"unsafe"
 )
 
@@ -395,13 +397,49 @@ func readForLength(wfl *ForLength, length int, r io.Reader) error {
 
 // WriteToFile writes the WMP to the given filename in MAGPIE-compatible
 // binary format.
+//
+// The write goes to a temporary file in the destination directory and is
+// renamed into place, so a reader never observes a half-written .wmp — an
+// interrupted write leaves a stray temp file rather than a corrupt lexicon
+// that later loads would keep failing on. This matters most on a shared
+// network filesystem where several processes may build the same WMP at
+// once; each writes its own temp file and the rename is atomic.
 func (wmp *WMP) WriteToFile(filename string) error {
-	f, err := os.Create(filename)
+	f, err := os.CreateTemp(filepath.Dir(filename), ".wmp-tmp-*")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	return wmp.Write(f)
+	tmp := f.Name()
+	defer func() {
+		if tmp != "" {
+			f.Close()
+			os.Remove(tmp)
+		}
+	}()
+
+	bw := bufio.NewWriterSize(f, 1<<20)
+	if err := wmp.Write(bw); err != nil {
+		return err
+	}
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// CreateTemp uses 0600; WMPs are shared read-only data, and other
+	// processes/users need to read them.
+	if err := os.Chmod(tmp, 0644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, filename); err != nil {
+		return err
+	}
+	tmp = ""
+	return nil
 }
 
 // Write serializes the WMP to a writer.


### PR DESCRIPTION
## What

`EnsureWMP` built the WMP, wrote it to disk, then discarded the in-memory copy and re-read it via `GetWMP`. Two problems fall out of that:

1. **When the write fails, the built WMP is thrown away.** `GetWMP` then stats the still-missing file and errors. word-golib's cache [doesn't cache errors](https://github.com/domino14/word-golib/blob/master/cache/cache.go), so the *next* call rebuilds from scratch — ~1.4 s and ~550 MB transient for CSW24 — and the WMP is never actually used.
2. **`WriteToFile` was a bare `os.Create` on the destination.** An interrupted write (or two processes building the same lexicon at once) leaves a truncated `.wmp`. `os.Stat` accepts it, `Load` rejects it, and nothing ever rebuilds it — the WMP is silently off for good.

This is not hypothetical for the bot Lambda. Its EFS mount is read-only in practice: the Lambda sandbox runs as `uid=993`, while `/mnt/data/data/lexica` is owned by `uid=1000`, mode 0755. Verified with a throwaway probe function against the prod access point:

```
uid=993 euid=993 gid=990
/mnt/data/data/lexica   mode=drwxr-xr-x uid=1000 gid=1000
os.Create(/mnt/data/data/lexica/...): FAILED: permission denied
```

So on today's code every simming turn would rebuild the whole WMP and drop it on the floor.

## Changes

- `EnsureWMP` returns and memoizes the WMP it just built whether or not the save succeeds, so the build cost is paid once per process instead of once per call.
- `WriteToFile` writes to a temp file in the destination directory, fsyncs, chmods to 0644 (`CreateTemp` gives 0600, and these files are read by other users/processes), and renames into place. Readers never see a partial `.wmp`.
- A `.wmp` that exists but won't load now triggers a rebuild instead of failing for the life of the process.
- The build stays *outside* word-golib's cache load function, with a comment explaining why: that cache invokes load functions with its own non-reentrant mutex held, and both `kwg.GetKWG` and `ProbableLetterDistribution` take that same mutex — building inside one deadlocks.

## Testing

Three new tests in `wmp/cache_test.go`: the write is readable and leaves no temp files behind; a failed write leaves neither a partial file nor a temp file; and `EnsureWMP` against a read-only lexica directory still returns a usable WMP, creates nothing, and serves the second call from cache. The last one is skipped without `MACONDO_DATA_PATH` (or when running as root, where directory modes aren't enforced).

`go test $(go list ./... | grep -v wasm)` passes, and the branch builds and passes `./wmp/...` in a clean worktree.

## Note

Measured on a 4-thread build (≈ the Lambda's ~3.6 vCPU at 6000 MB): building CSW24 from its 6 MB KWG takes ~1.4 s, while loading a pre-built 171 MB `.wmp` over EFS would take ~1.8 s at the 100 MiB/s permitted throughput. Building in memory is not the slow path — the ~550 MB transient allocation is its only real cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)