### PR TITLE
Fix analyze-batch silently analyzing nothing

### DIFF
--- a/gameanalysis/analyzer.go
+++ b/gameanalysis/analyzer.go
@@ -250,6 +250,22 @@ func (a *Analyzer) AnalyzeGame(ctx context.Context, history *pb.GameHistory) (*G
 	if history == nil {
 		return nil, errors.New("game history is nil")
 	}
+	if len(history.Players) < 2 {
+		return nil, fmt.Errorf("game has %d players, expected 2", len(history.Players))
+	}
+
+	// Resolve the -player name filter before doing any work. A filter that
+	// matches neither player is an error, not an empty analysis: silently
+	// reporting zero turns for every game looks exactly like a working run
+	// that found nothing.
+	nameFilterIdx := -1
+	if a.analysisCfg.OnlyPlayerByName != "" {
+		nameFilterIdx = playerIndexByName(history.Players, a.analysisCfg.OnlyPlayerByName)
+		if nameFilterIdx == -1 {
+			return nil, fmt.Errorf("no player named %q in this game (players: %s)",
+				a.analysisCfg.OnlyPlayerByName, describePlayers(history.Players))
+		}
+	}
 
 	result := &GameAnalysisResult{
 		Turns:           make([]*TurnAnalysis, 0),
@@ -294,8 +310,8 @@ func (a *Analyzer) AnalyzeGame(ctx context.Context, history *pb.GameHistory) (*G
 	// Determine which player to analyze
 	shouldAnalyzePlayer := func(playerIndex int) bool {
 		// Check name filter first
-		if a.analysisCfg.OnlyPlayerByName != "" {
-			return history.Players[playerIndex].Nickname == a.analysisCfg.OnlyPlayerByName
+		if nameFilterIdx != -1 {
+			return playerIndex == nameFilterIdx
 		}
 		// Then check player index filter
 		if a.analysisCfg.OnlyPlayer == -1 {
@@ -357,6 +373,113 @@ func (a *Analyzer) AnalyzeGame(ctx context.Context, history *pb.GameHistory) (*G
 	a.calculatePlayerSummaries(result)
 
 	return result, nil
+}
+
+// playerIndexByName finds the player a -player name filter refers to, or -1.
+// A GCG nickname is a single whitespace-free token (`#player1 nick Real Name`),
+// so a filter like "Eric Smith" can only ever be a real name; both fields are
+// matched, case-insensitively, so the user does not have to know which form
+// the file used.
+func playerIndexByName(players []*pb.PlayerInfo, name string) int {
+	name = strings.TrimSpace(name)
+	for i, p := range players {
+		if p == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(p.Nickname), name) ||
+			strings.EqualFold(strings.TrimSpace(p.RealName), name) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Coverage says whether an already-computed analysis answers what an
+// AnalysisConfig asks for. An analysis restricted to one player does not
+// answer a question about both, and reusing it would quietly report half a
+// game as the whole of it.
+type Coverage int
+
+const (
+	// CoverageComplete: the analysis covers every player the config asks for.
+	CoverageComplete Coverage = iota
+	// CoveragePartial: some requested player has no analyzed turns.
+	CoveragePartial
+	// CoverageUnknown: the answer depends on the game's player list, which
+	// the caller did not supply. Ask again with it.
+	CoverageUnknown
+)
+
+// Covers reports whether r already answers what cfg asks for. players is the
+// game's player list; pass nil if it is not loaded yet, and handle
+// CoverageUnknown by loading it and asking again.
+//
+// A player with no analyzed turns is how a stored result records "this player
+// was filtered out", since every player in a real game takes at least one turn.
+func (r *GameAnalysisResult) Covers(cfg *AnalysisConfig, players []*pb.PlayerInfo) Coverage {
+	analyzed := func(i int) bool {
+		return i >= 0 && i < len(r.PlayerSummaries) &&
+			r.PlayerSummaries[i] != nil && r.PlayerSummaries[i].TurnsPlayed > 0
+	}
+	bothAnalyzed := func() Coverage {
+		if analyzed(0) && analyzed(1) {
+			return CoverageComplete
+		}
+		return CoveragePartial
+	}
+
+	if cfg.OnlyPlayerByName == "" {
+		if cfg.OnlyPlayer == 0 || cfg.OnlyPlayer == 1 {
+			if analyzed(cfg.OnlyPlayer) {
+				return CoverageComplete
+			}
+			return CoveragePartial
+		}
+		return bothAnalyzed()
+	}
+
+	if len(players) > 0 {
+		// The player list is authoritative, including about a name that
+		// belongs to neither player: re-analyzing is what surfaces that.
+		idx := playerIndexByName(players, cfg.OnlyPlayerByName)
+		if idx != -1 && analyzed(idx) {
+			return CoverageComplete
+		}
+		return CoveragePartial
+	}
+
+	// Summaries carry nicknames only, so a filter naming a player in full
+	// cannot be resolved from a stored analysis alone.
+	for i, s := range r.PlayerSummaries {
+		if s != nil && strings.EqualFold(strings.TrimSpace(s.PlayerName),
+			strings.TrimSpace(cfg.OnlyPlayerByName)) {
+			if analyzed(i) {
+				return CoverageComplete
+			}
+			return CoveragePartial
+		}
+	}
+	return CoverageUnknown
+}
+
+// describePlayers renders the players of a game for error messages, showing
+// both names when they differ so the reader can see what -player would accept.
+func describePlayers(players []*pb.PlayerInfo) string {
+	names := make([]string, 0, len(players))
+	for _, p := range players {
+		if p == nil {
+			continue
+		}
+		name := p.Nickname
+		if p.RealName != "" && !strings.EqualFold(p.RealName, p.Nickname) {
+			name = fmt.Sprintf("%s (%s)", p.Nickname, p.RealName)
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
 }
 
 // isAnalyzableEvent returns true if the event represents a move that can be analyzed

--- a/gameanalysis/analyzer_test.go
+++ b/gameanalysis/analyzer_test.go
@@ -2,6 +2,7 @@ package gameanalysis
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/domino14/macondo/config"
@@ -238,6 +239,103 @@ func TestAnalyzeGame_NilHistory(t *testing.T) {
 	_, err := analyzer.AnalyzeGame(ctx, nil)
 	if err == nil {
 		t.Error("expected error for nil history")
+	}
+}
+
+func TestPlayerIndexByName(t *testing.T) {
+	// A GCG player line is `#player1 <nickname> <full name>`, so the nickname
+	// never contains a space and a two-word filter can only be a full name.
+	players := []*pb.PlayerInfo{
+		{Nickname: "esmith", RealName: "Eric Smith"},
+		{Nickname: "sammy", RealName: "Sammy Okosagah"},
+	}
+
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"esmith", 0},
+		{"Eric Smith", 0},
+		{"eric smith", 0},
+		{"  Eric Smith  ", 0},
+		{"SAMMY", 1},
+		{"Sammy Okosagah", 1},
+		{"Eric", -1},
+		{"Smith", -1},
+		{"", -1},
+	}
+
+	for _, tt := range tests {
+		if got := playerIndexByName(players, tt.name); got != tt.want {
+			t.Errorf("playerIndexByName(%q) = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+// A -player filter that matches nobody must fail loudly. Analyzing zero turns
+// and calling it a success is indistinguishable from a game with no mistakes.
+func TestAnalyzeGame_UnknownPlayerName(t *testing.T) {
+	analysisCfg := DefaultAnalysisConfig()
+	analysisCfg.OnlyPlayerByName = "Nobody Here"
+	analyzer := New(&config.Config{}, analysisCfg, "")
+
+	_, err := analyzer.AnalyzeGame(context.Background(), &pb.GameHistory{
+		Players: []*pb.PlayerInfo{
+			{Nickname: "esmith", RealName: "Eric Smith"},
+			{Nickname: "sammy", RealName: "Sammy Okosagah"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected an error for a player name that matches neither player")
+	}
+	if !strings.Contains(err.Error(), "Eric Smith") {
+		t.Errorf("error should name the players actually in the game, got: %v", err)
+	}
+}
+
+func TestGameAnalysisResult_Covers(t *testing.T) {
+	players := []*pb.PlayerInfo{
+		{Nickname: "esmith", RealName: "Eric Smith"},
+		{Nickname: "sammy", RealName: "Sammy Okosagah"},
+	}
+	result := func(turns0, turns1 int) *GameAnalysisResult {
+		return &GameAnalysisResult{PlayerSummaries: [2]*PlayerSummary{
+			{PlayerName: "esmith", TurnsPlayed: turns0},
+			{PlayerName: "sammy", TurnsPlayed: turns1},
+		}}
+	}
+	full, firstOnly := result(12, 11), result(12, 0)
+
+	tests := []struct {
+		name     string
+		result   *GameAnalysisResult
+		cfg      *AnalysisConfig
+		players  []*pb.PlayerInfo
+		expected Coverage
+	}{
+		{"both players, full analysis", full, &AnalysisConfig{OnlyPlayer: -1}, nil, CoverageComplete},
+		{"both players, one-sided analysis", firstOnly, &AnalysisConfig{OnlyPlayer: -1}, nil, CoveragePartial},
+		{"player 0, one-sided analysis", firstOnly, &AnalysisConfig{OnlyPlayer: 0}, nil, CoverageComplete},
+		{"player 1, one-sided analysis", firstOnly, &AnalysisConfig{OnlyPlayer: 1}, nil, CoveragePartial},
+		{"nickname resolvable from summaries", firstOnly,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "esmith"}, nil, CoverageComplete},
+		{"other nickname, not analyzed", firstOnly,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "sammy"}, nil, CoveragePartial},
+		// Summaries hold nicknames, so a full name needs the player list.
+		{"full name without players", firstOnly,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "Eric Smith"}, nil, CoverageUnknown},
+		{"full name with players", firstOnly,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "Eric Smith"}, players, CoverageComplete},
+		{"full name with players, not analyzed", firstOnly,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "Sammy Okosagah"}, players, CoveragePartial},
+		{"name belonging to neither player", full,
+			&AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "Nobody"}, players, CoveragePartial},
+	}
+
+	for _, tt := range tests {
+		if got := tt.result.Covers(tt.cfg, tt.players); got != tt.expected {
+			t.Errorf("%s: Covers = %v, expected %v", tt.name, got, tt.expected)
+		}
 	}
 }
 

--- a/shell/analyze_batch.go
+++ b/shell/analyze_batch.go
@@ -14,11 +14,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/domino14/macondo/config"
 	"github.com/domino14/macondo/game"
 	"github.com/domino14/macondo/gameanalysis"
 	pb "github.com/domino14/macondo/gen/api/proto/macondo"
+	"github.com/domino14/macondo/turnplayer"
+	wmppkg "github.com/domino14/macondo/wmp"
 )
 
 // GameSource represents a source for loading a game
@@ -55,37 +59,73 @@ func parseGameSource(source string) (*GameSource, error) {
 			Original:   source,
 		}, nil
 	} else {
-		// A path, either a single game or a folder of them. A path that can't
+		// A path, either a single game or a folder of them. Stat follows
+		// symlinks, so a link to a folder is a folder here. A path that can't
 		// be stat'ed is left as a file so the loader reports what went wrong.
-		if info, err := os.Stat(source); err == nil && info.IsDir() {
+		path := expandHomePath(source)
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
 			return &GameSource{
 				Type:       "dir",
-				Identifier: source,
-				Original:   source,
+				Identifier: path,
+				Original:   path,
 			}, nil
 		}
 		return &GameSource{
 			Type:       "file",
-			Identifier: source,
-			Original:   source,
+			Identifier: path,
+			Original:   path,
 		}, nil
 	}
 }
 
-// gcgFilesInDir returns every .gcg file at or below dir, in the order WalkDir
-// visits them, which is lexical within each directory.
+// gcgFilesInDir returns every .gcg file at or below dir, lexically within each
+// directory. Unlike filepath.WalkDir it follows symlinks, since a folder of
+// games is as likely to be a link as a real directory and silently finding
+// nothing there is worse than the cost of resolving them; already-visited
+// directories are remembered so a link back up the tree cannot loop forever.
 func gcgFilesInDir(dir string) ([]string, error) {
 	var paths []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	seen := map[string]bool{}
+
+	var walk func(dir string) error
+	walk = func(dir string) error {
+		// Loop protection keys on the resolved path, so the same directory
+		// reached by two different links is only walked once.
+		resolved, err := filepath.EvalSymlinks(dir)
 		if err != nil {
 			return err
 		}
-		if !d.IsDir() && strings.EqualFold(filepath.Ext(path), ".gcg") {
-			paths = append(paths, path)
+		if seen[resolved] {
+			return nil
+		}
+		seen[resolved] = true
+
+		entries, err := os.ReadDir(dir) // sorted by filename
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			path := filepath.Join(dir, e.Name())
+			isDir := e.IsDir()
+			if e.Type()&fs.ModeSymlink != 0 {
+				info, err := os.Stat(path) // follows the link
+				if err != nil {
+					continue // dangling link; nothing to analyze
+				}
+				isDir = info.IsDir()
+			}
+			if isDir {
+				if err := walk(path); err != nil {
+					return err
+				}
+			} else if strings.EqualFold(filepath.Ext(path), ".gcg") {
+				paths = append(paths, path)
+			}
 		}
 		return nil
-	})
-	if err != nil {
+	}
+
+	if err := walk(dir); err != nil {
 		return nil, err
 	}
 	return paths, nil
@@ -144,6 +184,41 @@ func (sc *ShellController) fetchWooglesCollection(collectionID string) ([]string
 	}
 
 	return gameIDs, nil
+}
+
+// reuseUndecided is the reason reusableAnalysis gives when it cannot decide
+// without the game's player list.
+const reuseUndecided = "undecided"
+
+// reusableAnalysis returns the stored analysis if it can stand in for
+// re-analyzing the game, or nil and the reason it cannot. players may be nil
+// when the game history has not been loaded yet; a reuseUndecided reason means
+// the caller should load it and ask again.
+//
+// The stored row is not proof on its own: it may predate the fields this
+// version reports, or have been produced under a -player filter that answers
+// a narrower question than the one being asked now.
+func reusableAnalysis(stored *gameanalysis.StoredAnalysis, cfg *gameanalysis.AnalysisConfig,
+	players []*pb.PlayerInfo) (*gameanalysis.GameAnalysisResult, string) {
+
+	if stored.AnalysisVersion < gameanalysis.CurrentAnalysisVersion {
+		return nil, fmt.Sprintf("stored analysis is version %d, current is %d",
+			stored.AnalysisVersion, gameanalysis.CurrentAnalysisVersion)
+	}
+	resultProto := &pb.GameAnalysisResult{}
+	if err := protojson.Unmarshal(stored.ResultJSON, resultProto); err != nil {
+		return nil, fmt.Sprintf("stored analysis could not be read: %v", err)
+	}
+	result := gameanalysis.GameAnalysisResultFromProto(resultProto)
+
+	switch result.Covers(cfg, players) {
+	case gameanalysis.CoverageComplete:
+		return result, ""
+	case gameanalysis.CoverageUnknown:
+		return nil, reuseUndecided
+	default:
+		return nil, "stored analysis does not cover the requested player"
+	}
 }
 
 // loadGameHistoryFromSource loads a game history from a GameSource
@@ -279,6 +354,31 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 	}
 	var exportEntries []batchExportEntry
 
+	// Without -continue the first failure stops the batch, but whatever was
+	// analyzed before it is still worth reporting, so the run unwinds through
+	// abortErr rather than returning from inside the loop.
+	var abortErr error
+
+	// Nothing in the batch path goes through `load`, so no lexicon has been
+	// fetched for these games. Do it once per distinct lexicon, remembering
+	// failures so a folder of games in an unavailable lexicon does not retry
+	// the download once per file.
+	ensuredLexica := map[string]error{}
+	ensureLexicon := func(lexicon string) error {
+		if err, done := ensuredLexica[lexicon]; done {
+			return err
+		}
+		err := turnplayer.EnsureKWG(lexicon, sc.config.WGLConfig())
+		if err != nil {
+			err = fmt.Errorf("could not ensure lexicon %s: %w", lexicon, err)
+		} else if _, wmpErr := wmppkg.EnsureWMP(sc.config.WGLConfig(), lexicon); wmpErr != nil {
+			log.Info().Err(wmpErr).Str("lexicon", lexicon).
+				Msg("WMP not available for this lexicon; sim will use the KWG algorithm")
+		}
+		ensuredLexica[lexicon] = err
+		return err
+	}
+
 	for i, source := range sources {
 		sc.showMessage(fmt.Sprintf("Analyzing game %d/%d: %s", i+1, len(sources), source.Original))
 
@@ -286,19 +386,36 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 			GameID: source.Original,
 		}
 
-		// Check if already in DB (skip unless -force)
-		if store != nil && store.Exists(source.Original) && !force {
-			sc.showMessage(fmt.Sprintf("  Skipping '%s' (already analyzed). Use -force to overwrite.", source.Original))
-			// Load from DB so batch stats still include it
-			stored, err := store.Get(source.Original)
-			if err == nil {
-				resultProto := &pb.GameAnalysisResult{}
-				if err := protojson.Unmarshal(stored.ResultJSON, resultProto); err == nil {
-					gameResult.GameInfo = stored.PlayerInfo
-					gameResult.Result = gameanalysis.GameAnalysisResultFromProto(resultProto)
-				}
+		// A stored analysis stands in for re-running the game, but only if it
+		// answers what this run asks. Coverage can depend on the game's player
+		// list, which is not known until the history is loaded, so the check
+		// runs again below for the games that need it.
+		var stored *gameanalysis.StoredAnalysis
+		if store != nil && !force {
+			if s, err := store.Get(source.Original); err == nil {
+				stored = s
 			}
+		}
+		reuse := func(players []*pb.PlayerInfo) bool {
+			if stored == nil {
+				return false
+			}
+			result, reason := reusableAnalysis(stored, cfg, players)
+			if reason == reuseUndecided {
+				return false // decide after the history is loaded
+			}
+			if result == nil {
+				sc.showMessage(fmt.Sprintf("  Re-analyzing '%s': %s", source.Original, reason))
+				stored = nil
+				return false
+			}
+			sc.showMessage(fmt.Sprintf("  Skipping '%s' (already analyzed). Use -force to overwrite.", source.Original))
+			gameResult.GameInfo = stored.PlayerInfo
+			gameResult.Result = result
 			batchResult.AddGameResult(gameResult)
+			return true
+		}
+		if reuse(nil) {
 			continue
 		}
 
@@ -309,7 +426,8 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 			batchResult.AddGameResult(gameResult)
 
 			if !continueOnError {
-				return nil, fmt.Errorf("failed to load game %s: %w", source.Original, err)
+				abortErr = fmt.Errorf("failed to load game %s: %w", source.Original, err)
+				break
 			}
 			sc.showMessage(fmt.Sprintf("  Error loading: %v", err))
 			continue
@@ -322,13 +440,27 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 				history.Players[1].Nickname)
 		}
 
-		// Validate racks before analysis to catch corrupt games early.
-		boardLayout, ldName, variant := game.HistoryToVariant(history)
-		rules, err := game.NewBasicGameRules(sc.config, history.Lexicon, boardLayout, ldName,
-			game.CrossScoreAndSet, variant)
+		// The players are known now, so a reuse decision that depended on
+		// them can be made.
+		if reuse(history.Players) {
+			continue
+		}
+
+		// Make sure the lexicon these games were played in is on disk, the
+		// way `load` does, then validate racks to catch corrupt games early.
+		if history.Lexicon == "" {
+			history.Lexicon = sc.config.GetString(config.ConfigDefaultLexicon)
+		}
+		err = ensureLexicon(history.Lexicon)
 		if err == nil {
-			if vErr := validateGameHistory(history, rules.LetterDistribution().TileMapping()); vErr != nil {
-				err = fmt.Errorf("game history is corrupt: %w", vErr)
+			boardLayout, ldName, variant := game.HistoryToVariant(history)
+			var rules *game.GameRules
+			rules, err = game.NewBasicGameRules(sc.config, history.Lexicon, boardLayout, ldName,
+				game.CrossScoreAndSet, variant)
+			if err == nil {
+				if vErr := validateGameHistory(history, rules.LetterDistribution().TileMapping()); vErr != nil {
+					err = fmt.Errorf("game history is corrupt: %w", vErr)
+				}
 			}
 		}
 		if err != nil {
@@ -336,7 +468,8 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 			batchResult.AddGameResult(gameResult)
 
 			if !continueOnError {
-				return nil, fmt.Errorf("failed to validate game %s: %w", source.Original, err)
+				abortErr = fmt.Errorf("failed to validate game %s: %w", source.Original, err)
+				break
 			}
 			sc.showMessage(fmt.Sprintf("  Error validating: %v", err))
 			continue
@@ -349,7 +482,9 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 			batchResult.AddGameResult(gameResult)
 
 			if !continueOnError {
-				return nil, fmt.Errorf("failed to analyze game %s: %w", source.Original, err)
+				abortErr = fmt.Errorf("failed to analyze game %s: %w (use -continue to skip bad games)",
+					source.Original, err)
+				break
 			}
 			sc.showMessage(fmt.Sprintf("  Error analyzing: %v", err))
 			continue
@@ -399,6 +534,12 @@ func (sc *ShellController) analyzeBatch(cmd *shellcmd) (*Response, error) {
 
 	// Format output
 	output := sc.formatBatchResults(batchResult, summaryOnly)
+	if abortErr != nil {
+		// The shell prints either the response or the error, so show the
+		// results of the games that did finish before reporting the failure.
+		sc.showMessage(output)
+		return nil, abortErr
+	}
 	return msg(output), nil
 }
 
@@ -441,6 +582,7 @@ func (sc *ShellController) formatBatchResults(batch *gameanalysis.BatchAnalysisR
 	sb.WriteString(fmt.Sprintf("Failed: %d\n\n", batch.FailedGames))
 
 	// Per-game results
+	rowsWritten := 0
 	if len(batch.Games) > 0 {
 		sb.WriteString("Per-Game Results:\n")
 		sb.WriteString(fmt.Sprintf("%-25s  %-15s  %-6s  %-6s  %-6s  %-6s  %-6s\n",
@@ -488,8 +630,12 @@ func (sc *ShellController) formatBatchResults(batch *gameanalysis.BatchAnalysisR
 						smallCount,
 						mediumCount,
 						largeCount))
+					rowsWritten++
 				}
 			}
+		}
+		if rowsWritten == 0 {
+			sb.WriteString("(no turns were analyzed in any game)\n")
 		}
 		sb.WriteString("\n")
 	}

--- a/shell/analyze_test.go
+++ b/shell/analyze_test.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/domino14/macondo/gameanalysis"
+	pb "github.com/domino14/macondo/gen/api/proto/macondo"
 )
 
 // TestParseGameSource_Folder covers #508: a path is a folder source when it is
@@ -90,6 +93,142 @@ func TestGCGFilesInDir(t *testing.T) {
 
 	if _, err := gcgFilesInDir(filepath.Join(dir, "nope")); err == nil {
 		t.Error("expected an error for a missing folder")
+	}
+}
+
+// Symlinked folders are ordinary folders to the user, so they have to be
+// walked; filepath.WalkDir would have skipped them and reported no games.
+func TestGCGFilesInDir_Symlinks(t *testing.T) {
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	if err := os.MkdirAll(real, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(real, "a.gcg"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// A link used as the folder argument.
+	paths, err := gcgFilesInDir(link)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Errorf("symlinked folder: got %v, expected one .gcg file", paths)
+	}
+
+	// A link nested inside the folder being scanned. "real" and "link" both
+	// resolve to the same directory, so the file is reported once.
+	paths, err = gcgFilesInDir(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Errorf("folder containing a symlink: got %v, expected one .gcg file", paths)
+	}
+
+	// A link pointing at its own parent must not loop forever.
+	if err := os.Symlink(root, filepath.Join(real, "up")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := gcgFilesInDir(root); err != nil {
+		t.Fatalf("unexpected error walking a cyclic link: %v", err)
+	}
+
+	// A dangling link is skipped rather than failing the whole scan.
+	if err := os.Symlink(filepath.Join(root, "gone"), filepath.Join(root, "dead.gcg")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := gcgFilesInDir(root); err != nil {
+		t.Fatalf("unexpected error walking a dangling link: %v", err)
+	}
+}
+
+// The shell has no OS shell in front of it, so "~/games" arrives verbatim and
+// has to be expanded before it can be recognized as a folder.
+func TestParseGameSource_Tilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory: %v", err)
+	}
+	dir, err := os.MkdirTemp(home, "macondo-gcg-test-")
+	if err != nil {
+		t.Skipf("cannot create a folder under home: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	rel, err := filepath.Rel(home, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parseGameSource("~/" + rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type != "dir" {
+		t.Errorf("type = %q, expected %q", got.Type, "dir")
+	}
+	if got.Identifier != dir {
+		t.Errorf("identifier = %q, expected %q", got.Identifier, dir)
+	}
+}
+
+// A stored analysis is only a substitute for re-running a game when it
+// answers the question this run is asking.
+func TestReusableAnalysis(t *testing.T) {
+	storedFor := func(version int, turns0, turns1 int32) *gameanalysis.StoredAnalysis {
+		resultJSON, err := protojson.Marshal(&pb.GameAnalysisResult{
+			AnalysisVersion: int32(version),
+			PlayerSummaries: []*pb.PlayerSummary{
+				{PlayerName: "esmith", TurnsPlayed: turns0},
+				{PlayerName: "sammy", TurnsPlayed: turns1},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &gameanalysis.StoredAnalysis{AnalysisVersion: version, ResultJSON: resultJSON}
+	}
+	current := gameanalysis.CurrentAnalysisVersion
+	players := []*pb.PlayerInfo{
+		{Nickname: "esmith", RealName: "Eric Smith"},
+		{Nickname: "sammy", RealName: "Sammy Okosagah"},
+	}
+	bothPlayers := &gameanalysis.AnalysisConfig{OnlyPlayer: -1}
+	byFullName := &gameanalysis.AnalysisConfig{OnlyPlayer: -1, OnlyPlayerByName: "Eric Smith"}
+
+	tests := []struct {
+		name        string
+		stored      *gameanalysis.StoredAnalysis
+		cfg         *gameanalysis.AnalysisConfig
+		players     []*pb.PlayerInfo
+		expectReuse bool
+		expectWhy   string
+	}{
+		{"complete and current", storedFor(current, 12, 11), bothPlayers, nil, true, ""},
+		{"stale version", storedFor(current-1, 12, 11), bothPlayers, nil, false, "version"},
+		{"analyzed one player only", storedFor(current, 12, 0), bothPlayers, nil, false, "player"},
+		{"full name needs the player list", storedFor(current, 12, 0), byFullName, nil, false, reuseUndecided},
+		{"full name with the player list", storedFor(current, 12, 0), byFullName, players, true, ""},
+		{"unreadable result", &gameanalysis.StoredAnalysis{
+			AnalysisVersion: current, ResultJSON: []byte("not json")}, bothPlayers, nil, false, "could not be read"},
+	}
+
+	for _, tt := range tests {
+		result, why := reusableAnalysis(tt.stored, tt.cfg, tt.players)
+		if (result != nil) != tt.expectReuse {
+			t.Errorf("%s: reuse = %v, expected %v (reason %q)", tt.name, result != nil, tt.expectReuse, why)
+			continue
+		}
+		if !strings.Contains(why, tt.expectWhy) {
+			t.Errorf("%s: reason = %q, expected it to mention %q", tt.name, why, tt.expectWhy)
+		}
 	}
 }
 

--- a/shell/helptext/analyze-batch.txt
+++ b/shell/helptext/analyze-batch.txt
@@ -16,9 +16,15 @@ Example:
 This command analyzes multiple games from various sources and displays per-game
 analysis tables plus an aggregated summary. Each game's analysis is
 automatically saved to the local store so the results can be revisited later
-with `analyze-view` or listed with `analyze-browse`. If an analysis already
-exists for a game it is skipped (and reloaded from the store so the batch
-stats still include it); use -force to re-analyze and overwrite instead.
+with `analyze-view` or listed with `analyze-browse`.
+
+A game that has already been analyzed is skipped, and its stored analysis is
+reloaded so the batch stats still include it. A stored analysis is only reused
+when it still answers the question being asked: one written by an older
+version of the analyzer, or one produced under a narrower -player filter than
+this run uses, is analyzed again. Use -force to re-analyze everything.
+
+Lexicons the games were played in are downloaded as needed, once per lexicon.
 
 It supports loading games from:
 
@@ -26,10 +32,11 @@ It supports loading games from:
   - Woogles Collection: Use format "woogcollection:UUID" (fetches all games in collection)
   - Cross-tables: Use format "xt:GAMEID"
   - Local GCG files: Use file path (e.g., "/path/to/game.gcg")
-  - Folders of GCG files: Use a directory path (e.g., "/path/to/gcgs"). The
-    folder is searched recursively and every .gcg file found is analyzed, in
-    alphabetical order. Each file is stored under its own path, so re-running
-    the command skips the ones already analyzed unless -force is given.
+  - Folders of GCG files: Use a directory path (e.g., "/path/to/gcgs" or
+    "~/Downloads/wordcup"). The folder is searched recursively, following
+    symlinks, and every .gcg file found is analyzed in alphabetical order.
+    Each file is stored under its own path, so re-running the command skips
+    the ones already analyzed unless -force is given.
   - Web URLs: Use full HTTP/HTTPS URL
 
 Each game is analyzed using the same phase-appropriate analysis as the `analyze`
@@ -49,10 +56,14 @@ Options:
 
     Analyze only moves by player 1 (the second player) in all games.
 
-    -player "nickname"
+    -player "name"
 
-    Analyze only moves by the player with the specified nickname across all
-    games. The nickname must match exactly (case-sensitive).
+    Analyze only moves by the named player across all games. The name is
+    matched, ignoring case, against both the GCG nickname and the full name
+    (a GCG player line is `#player1 <nickname> <full name>`, so a name with a
+    space in it can only be the full name). A game in which no player matches
+    is reported as an error rather than analyzed as zero turns; pass -continue
+    to skip past games the player did not play in.
 
     -continue
 

--- a/shell/helptext/analyze.txt
+++ b/shell/helptext/analyze.txt
@@ -42,10 +42,13 @@ Options:
 
     Analyze only moves by player 1 (the second player).
 
-    -player "nickname"
+    -player "name"
 
-    Analyze only moves by the player with the specified nickname. The nickname
-    must match exactly (case-sensitive).
+    Analyze only moves by the named player. The name is matched, ignoring
+    case, against both the GCG nickname and the full name (a GCG player line
+    is `#player1 <nickname> <full name>`, so a name with a space in it can
+    only be the full name). If neither player matches, the command fails
+    instead of analyzing nothing.
 
     -json <file>
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1122,18 +1122,28 @@ func (sc *ShellController) loadGameHistoryFromWeb(url string) (*pb.GameHistory, 
 	return gcgio.ParseGCGFromReader(sc.config, resp.Body)
 }
 
+// expandHomePath expands a leading "~" or "~/" to the user's home directory.
+// The shell has no OS shell in front of it, so a tilde arrives verbatim and
+// every path the user types has to go through here. A path that cannot be
+// expanded comes back unchanged, so callers report what the user actually
+// typed.
+func expandHomePath(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	usr, err := user.Current()
+	if err != nil || usr.HomeDir == "" {
+		return path
+	}
+	if path == "~" {
+		return usr.HomeDir
+	}
+	return filepath.Join(usr.HomeDir, path[2:])
+}
+
 // loadGameHistoryFromFile loads a game from a local GCG file
 func (sc *ShellController) loadGameHistoryFromFile(path string) (*pb.GameHistory, error) {
-	if strings.HasPrefix(path, "~/") {
-		usr, err := user.Current()
-		if err != nil {
-			return nil, err
-		}
-		dir := usr.HomeDir
-		path = filepath.Join(dir, path[2:])
-	}
-
-	return gcgio.ParseGCG(sc.config, path)
+	return gcgio.ParseGCG(sc.config, expandHomePath(path))
 }
 
 // lexiconFromCGP extracts the lexicon name from the ops field of a CGP string
@@ -1735,6 +1745,22 @@ func extractFields(line string) (*shellcmd, error) {
 	options := CmdOptions{}
 	// handle options
 
+	// A declared boolean flag does not take a value unless one is written out,
+	// so `analyze-batch -continue /path/to/games` reads the path as an
+	// argument rather than swallowing it as the flag's value.
+	spec := commandSpecs[cmd]
+	takesFollowingValue := func(name, next string) bool {
+		if spec == nil {
+			return true
+		}
+		opt := spec.lookupOption(name)
+		if opt == nil || opt.Type != OptBool {
+			return true
+		}
+		next = strings.ToLower(next)
+		return next == "true" || next == "false"
+	}
+
 	lastWasOption := false
 	lastOption := ""
 	for idx := 1; idx < len(fields); idx++ {
@@ -1752,7 +1778,12 @@ func extractFields(line string) (*shellcmd, error) {
 		}
 		if lastWasOption {
 			lastWasOption = false
-			options[lastOption] = append(options[lastOption], fields[idx])
+			if takesFollowingValue(lastOption, fields[idx]) {
+				options[lastOption] = append(options[lastOption], fields[idx])
+			} else {
+				options[lastOption] = append(options[lastOption], "true")
+				args = append(args, fields[idx])
+			}
 		} else {
 			args = append(args, fields[idx])
 		}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -29,6 +29,30 @@ func TestExtractFields(t *testing.T) {
 		},
 		// {"autoplay exhaustiveleave noleave -file",
 		// 	nil, errWrongOptionSyntax},
+
+		// A declared boolean flag does not eat the argument after it...
+		{"analyze-batch -continue /path/to/games",
+			&shellcmd{"analyze-batch",
+				[]string{"/path/to/games"},
+				map[string][]string{"continue": {"true"}}},
+			nil},
+		{"analyze-batch -force -continue /path/to/games",
+			&shellcmd{"analyze-batch",
+				[]string{"/path/to/games"},
+				map[string][]string{"force": {"true"}, "continue": {"true"}}},
+			nil},
+		// ...but still takes a value when one is written out.
+		{"analyze-batch -continue false /path/to/games",
+			&shellcmd{"analyze-batch",
+				[]string{"/path/to/games"},
+				map[string][]string{"continue": {"false"}}},
+			nil},
+		// Options that take a value are unaffected.
+		{"analyze-batch -player \"Eric Smith\" /path/to/games",
+			&shellcmd{"analyze-batch",
+				[]string{"/path/to/games"},
+				map[string][]string{"player": {"Eric Smith"}}},
+			nil},
 	}
 	for _, t := range cases {
 		cmd, err := extractFields(t.line)

--- a/shell/spec_smoke_test.go
+++ b/shell/spec_smoke_test.go
@@ -46,7 +46,10 @@ func TestPegSpecValidation(t *testing.T) {
 		{"peg -skip-deep-pass false", false, ""},
 		{"peg -only-solve X -only-solve Y", false, ""},
 		{"peg -endgameplies abc", true, "invalid int"},
-		{"peg -skip-loss maybe", true, "invalid bool"},
+		// A boolean flag does not take a non-boolean value: -skip-loss is set
+		// and "maybe" is left as an argument, which peg itself rejects as an
+		// unknown subcommand. This is what lets `-flag /some/path` work.
+		{"peg -skip-loss maybe", false, ""},
 		{"peg -skip-non-emptyers true", true, "unknown option"},
 		{"peg -skip-non-emptying true", true, "-max-tiles-left 0"}, // deprecated → helpful message
 		{"peg stop", false, ""},


### PR DESCRIPTION
`analyze-batch` had several ways to report success while analyzing no turns at all, or to fail on a whole folder that analyzes fine file by file. This came out of a real run: 31 games, each "analyzed" in the same second, ending in two empty tables.

```
macondo> analyze-batch -player "Eric Smith" "/Users/.../word-cup-gcg"
  Found 31 .gcg files
Analyzing game 1/31: .../round-01-sammy-okosagah.gcg
Analyzing game 2/31: .../round-02-dan-blake.gcg
...
Total games: 31
Successful: 31
Failed: 0
```

## The `-player` filter could not match a full name

A GCG player line is `#player1 <nickname> <full name>` and the nickname is `\S+`, so it never contains a space. The filter compared only against `Nickname`, exactly, so `-player "Eric Smith"` matched nobody: every turn was skipped, `AnalyzeGame` returned a zero-turn result, `AddGameResult` counted it as **successful**, and the summary tables hide rows with `TurnsPlayed == 0`.

The filter now matches nickname or full name, ignoring case and surrounding whitespace, and a name that matches neither player is an error rather than an empty analysis:

```
Error analyzing: no player named "Nobody Here" in this game (players: esmith (Eric Smith), sammy (Sammy Okosagah))
```

## Folder discovery missed tildes and symlinks

`os.Stat` was called on the path as typed, so `~/games` was not recognized as a folder and went to the GCG parser as a file (`read /home/...: is a directory`). Tilde expansion now happens in one place, used by every path the shell takes — the shell has no OS shell in front of it, so a tilde always arrives verbatim.

`filepath.WalkDir` does not follow symlinks, including the root, while `os.Stat` does. A symlinked games folder was classified as a folder and then reported "No .gcg files found"; a symlinked subfolder was silently skipped. The walk now follows them, deduplicating by resolved path so a link back up the tree cannot loop, and skipping dangling links rather than failing the scan.

## The batch never fetched lexicons

`load` calls `EnsureKWG`/`EnsureWMP`, the batch path called neither and went straight to `NewBasicGameRules`, which only reads from disk. A folder of games in a lexicon you have not downloaded failed on every file while the same files analyzed fine one at a time — and started working after you loaded one by hand. It now ensures the lexicon once per distinct name, remembering failures so a folder does not retry a download per file.

## Stored analyses were reused blindly

Any existing row counted as "already analyzed". Results predating the current analysis version were never refreshed, and one produced under a narrower `-player` filter was reused to answer a broader question. Reuse now requires the row to parse, to be current, and to cover the players being asked about — where a summary with zero turns is how a stored result records "this player was filtered out". A filter naming a player in full cannot be resolved against stored nicknames, so that decision is retaken once the history is loaded, which costs a GCG parse rather than an analysis. Either way it says why:

```
Skipping '.../g1.gcg' (already analyzed). Use -force to overwrite.
Re-analyzing '.../g1.gcg': stored analysis is version 1, current is 2
Re-analyzing '.../g1.gcg': stored analysis does not cover the requested player
```

A full analysis still covers any single-player request, so it is never re-run and never downgraded to a filtered one.

## Boolean flags swallowed the following argument

`analyze-batch -continue /path/to/games` made the path the *value* of `-continue`, leaving zero sources. A flag declared `OptBool` now only takes a following token when it is written out as `true` or `false`.

⚠️ This changes one existing expectation: `peg -skip-loss maybe` used to fail option validation with "invalid bool" and is now parsed as the flag plus a positional, which `peg` rejects itself as an unknown subcommand. `spec_smoke_test.go` is updated to match.

## Smaller things

- An aborted batch (no `-continue`) prints the games that did finish instead of discarding the whole report.
- A summary with no analyzed turns says `(no turns were analyzed in any game)` instead of printing an empty table.
- `AnalyzeGame` no longer indexes `Players[0]`/`[1]` unguarded — a malformed one-player GCG would have panicked the shell.
- Help text for `analyze` and `analyze-batch` updated for the new `-player`, reuse, and folder semantics.

## Testing

- Unit tests for name matching, the unknown-name error, `Covers`, `reusableAnalysis`, and the new parser cases.
- Every reuse branch exercised end to end against a seeded store: complete+current → skip; one-sided + both requested → re-analyze; one-sided + that player requested → skip; stale version → re-analyze; `-player "Eric Smith"` against an `esmith`-only analysis → skip via the deferred check; `-player "Sammy Okosagah"` → re-analyze.
- Symlinked folder, tilde path, missing lexicon, and the unknown-player error all confirmed against a built shell.
- `go test ./shell/ ./gameanalysis/ ./gcgio/ ./game/` passes. The full `go test ./...` exceeds two minutes on the sim/endgame packages and was not run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)