### PR TITLE
Say what the notation and the zeroes actually mean

### DIFF
--- a/explainer/agent.go
+++ b/explainer/agent.go
@@ -13,13 +13,17 @@ import (
 	"github.com/domino14/macondo/ai/bot"
 	"github.com/domino14/macondo/config"
 	"github.com/domino14/macondo/equity"
+	"github.com/domino14/macondo/move"
 	"github.com/domino14/word-golib/tilemapping"
 	"github.com/rs/zerolog/log"
 )
 
 // PlayMetadata represents metadata about a Scrabble play
 type PlayMetadata struct {
-	Play           string `json:"play"`
+	Play string `json:"play"`
+	// WordFormed is the whole word the play makes, the tiles already on the
+	// board included. Empty for exchanges and passes.
+	WordFormed     string `json:"word_formed,omitempty"`
 	Score          int    `json:"score"`
 	TilesUsed      int    `json:"tiles_used"`
 	IsBingo        bool   `json:"is_bingo"`
@@ -376,6 +380,29 @@ func DottedPlay(playString string) string {
 	return sb.String()
 }
 
+// WordFormed is the whole word a play makes, playthrough included: L5
+// (BEL)FRIED makes BELFRIED, 2J TOQUE makes TOQUE. The letters outside the
+// parentheses are only the ones that came off the rack, so a play named by
+// those alone is a different word - a reader told about "FRIED" has been told
+// about a play that does not exist.
+//
+// It reads the word out of the notation, which every play in the fact pack
+// carries: they are all written by MoveDescriptionWithPlaythrough. A dotted
+// play is not one of those - it can only arrive as input - and its board
+// letters are not in the string to recover, so it gets "", as do exchanges
+// and passes, which are not words.
+func WordFormed(play string) string {
+	fields := strings.Fields(strings.TrimSpace(play))
+	if len(fields) != 2 || !reCoord.MatchString(strings.ToUpper(fields[0])) {
+		return ""
+	}
+	word := strings.ToUpper(fields[1])
+	if strings.Contains(word, ".") {
+		return ""
+	}
+	return parenRepl.Replace(word)
+}
+
 // GetPlayMetadata analyzes a play and returns metadata
 func (a *Analyzer) GetPlayMetadata(playString string) (*PlayMetadata, error) {
 	a.mu.Lock()
@@ -383,6 +410,16 @@ func (a *Analyzer) GetPlayMetadata(playString string) (*PlayMetadata, error) {
 	m, err := a.game.ParseMove(a.game.PlayerOnTurn(), false, strings.Fields(DottedPlay(playString)), false)
 	if err != nil {
 		return nil, err
+	}
+
+	// The word off the board rather than out of the notation: the model can
+	// ask about a play in dotted form, where the played-through letters are
+	// not in the string at all.
+	word := ""
+	if m.Action() == move.MoveTypePlay {
+		if words, err := a.game.Board().FormedWords(m); err == nil && len(words) > 0 {
+			word = words[0].UserVisible(a.game.Alphabet())
+		}
 	}
 
 	// Parse basic info from play string
@@ -413,6 +450,7 @@ func (a *Analyzer) GetPlayMetadata(playString string) (*PlayMetadata, error) {
 
 	md := &PlayMetadata{
 		Play:           playString,
+		WordFormed:     word,
 		Score:          m.Score(),
 		TilesUsed:      tilesUsed,
 		IsBingo:        isBingo,

--- a/explainer/comparison_test.go
+++ b/explainer/comparison_test.go
@@ -28,6 +28,53 @@ func TestDottedPlay(t *testing.T) {
 	is.Equal(DottedPlay("  8H QUIXOTIC  "), "8H QUIXOTIC")
 }
 
+func TestWordFormed(t *testing.T) {
+	is := is.New(t)
+
+	// The word is the whole thing, playthrough included: this is the play a
+	// reader would otherwise be told was "FRIED".
+	is.Equal(WordFormed("L5 (BEL)FRIED"), "BELFRIED")
+	is.Equal(WordFormed("5D (S)PIC(A)"), "SPICA")
+	is.Equal(WordFormed("2J TOQUE"), "TOQUE")
+	// A blank is still the letter it was played as, in the word.
+	is.Equal(WordFormed("1H (Z)WIEBAcK"), "ZWIEBACK")
+	// Not words, and not recoverable: exchanges, passes, and the dotted form,
+	// which the fact pack never uses but the model can type.
+	is.Equal(WordFormed("5D .PIC."), "")
+	is.Equal(WordFormed("(exch QU)"), "")
+	is.Equal(WordFormed("pass"), "")
+	is.Equal(WordFormed("(Pass)"), "")
+
+	// The note is only worth writing where the notation hides something.
+	is.Equal(hiddenWord("L5 (BEL)FRIED"), "BELFRIED")
+	is.Equal(hiddenWord("2J TOQUE"), "")
+	is.Equal(hiddenWord("(exch QU)"), "")
+}
+
+// Both places the model reads a play before writing about it have to spell it
+// out, or a play made through BEL comes back to the reader as FRIED.
+func TestRenderedPlaysCarryTheirWord(t *testing.T) {
+	is := is.New(t)
+
+	rival := &montecarlo.CandidateStats{Play: "L5 (BEL)FRIED", Score: 29}
+	best := &montecarlo.CandidateStats{Play: "2J TOQUE", Score: 36}
+	f := &PositionFacts{
+		Best:       best,
+		Candidates: []montecarlo.CandidateStats{*best, *rival},
+		Flags:      Flags{},
+		Comparison: &Comparison{Play: rival.Play, Rival: rival, FromHistory: true},
+	}
+
+	table := f.renderCandidates()
+	is.True(strings.Contains(table, "makes BELFRIED"))
+	// A play with nothing played through says nothing; it is already its word.
+	is.True(!strings.Contains(table, "makes TOQUE"))
+
+	head := f.renderComparison()
+	is.True(strings.Contains(head, "L5 (BEL)FRIED makes the word BELFRIED"))
+	is.True(!strings.Contains(head, "2J TOQUE makes the word"))
+}
+
 // The play we were asked about has to survive the cut however badly it did -
 // the whole point is to explain a move that lost.
 func TestTrimCandidatesKeepsTheComparison(t *testing.T) {
@@ -143,6 +190,7 @@ func TestComparisonPrompt(t *testing.T) {
 	is.True(strings.Contains(p.User, "Chances only in the sampled follow-ups after 12K QU(ID)"))
 	// The upside contrast is the figure that carries "you gave something up".
 	is.True(strings.Contains(p.User, "Big follow-up upside"))
+	is.True(strings.Contains(p.User, "10.2 pts after 12K QU(ID)"))
 	// And the next-turn edge is split, so the model can't argue the mean
 	// difference and the upside difference as if they were two findings.
 	is.True(strings.Contains(p.User,
@@ -150,6 +198,44 @@ func TestComparisonPrompt(t *testing.T) {
 
 	// And the question being asked changes accordingly.
 	is.True(strings.Contains(p.User, "why 12K QU(ID) beats 5D (S)CAP(A), the play they played"))
+}
+
+// A play with nothing that cleared the bar has no upside figure, and must not
+// be given one. "0.0 pts" formats exactly like a measurement, and every figure
+// in that section is one the model is told to quote, so it came back out at
+// readers as "your follow-up upside is 0.0" - a field name and a number that
+// reads like a verdict on their play rather than the absence it is.
+func TestNoChanceIsWordsNotZero(t *testing.T) {
+	is := is.New(t)
+	f := comparedFacts(false)
+	f.Comparison.Deltas.RivalUpside = 0
+
+	p, err := BuildPrompt(f, false)
+	is.NoErr(err)
+	is.True(strings.Contains(p.User,
+		"10.2 pts after 12K QU(ID), no big follow-up chance after 5D (S)CAP(A)"))
+	is.True(!strings.Contains(p.User, "0.0 pts"))
+}
+
+// The head to head renders the rival's chances whether or not the best play
+// has any of its own, so the guidance on how to talk about a big chance has to
+// come along with them. Otherwise a chance belonging to the play the reader
+// actually made reaches the model with nothing telling it what to do with it.
+func TestRivalChanceLoadsTheConcept(t *testing.T) {
+	is := is.New(t)
+	f := comparedFacts(false)
+	f.Chances = nil
+	f.Comparison.RivalChances = []*FollowupCluster{{
+		Anchor: "(QUAD) in row 2", Pct: 6.2, AvgScore: 74,
+		MinScore: 68, MaxScore: 81, IsBigChance: true, Upside: 2.1,
+	}}
+
+	f.Flags = computeFlags(f)
+	is.True(f.Flags["has_big_chance"])
+
+	p, err := BuildPrompt(f, false)
+	is.NoErr(err)
+	is.True(slices.Contains(p.Concepts, "big-chance"))
 }
 
 // An overlapping interval means the simulation has not shown a difference, and

--- a/explainer/concepts/big-chance.md
+++ b/explainer/concepts/big-chance.md
@@ -27,3 +27,10 @@ coordinate, say what has to be drawn, and quote both the score and the
 percentage. If a big chance exists after the recommended play and not after the
 alternatives, that is the headline and the aggregate figures are the
 supporting detail, not the other way round.
+
+State that absence as an absence. A play with no chance in its section has no
+upside figure at all - not an upside of zero - because nothing after it was
+both big enough and frequent enough to count. Say the plain thing: the reader's
+play leaves them an ordinary turn, whatever they draw. Naming a number there
+invites the reader to think their play was measured at zero and found wanting,
+when what happened is that it had nothing to measure.

--- a/explainer/concepts/notation.md
+++ b/explainer/concepts/notation.md
@@ -8,6 +8,12 @@ where the play starts, and parentheses go around tiles that were already on the
 board - that example plays C, O, K, I, E around an O already there to make
 COOKIE. A play that doesn't run through anything has no parentheses.
 
+The parenthesized letters are part of the word. `L5 (BEL)FRIED` is the play
+BELFRIED, made by adding FRIED to a BEL already on the board - it is not a play
+called "FRIED", and a reader told they played FRIED has been told about a word
+that isn't on the board. Refer to it as `L5 (BEL)FRIED` or as BELFRIED, never
+by the letters outside the parentheses on their own.
+
 A **lowercase** letter is a blank played as that letter: `12C COOKIe` scores the
 final E as a blank and is a different play from `12C COOKIE`. Never change the
 case of a play, either when you write it or when you pass it to a tool -

--- a/explainer/facts.go
+++ b/explainer/facts.go
@@ -1333,7 +1333,15 @@ func computeFlags(f *PositionFacts) Flags {
 	// Setups and big chances are judged per opportunity, not per play: four
 	// spellings of one hook are one thing to talk about, and each is too rare
 	// on its own to clear a bar the four of them clear together.
-	for _, ch := range f.Chances {
+	// The rival's chances count too. They are rendered in the head to head
+	// whether or not the best play has any, so a chance that belongs to the
+	// play the reader made would otherwise be put in front of the model with
+	// none of the guidance on how to talk about it.
+	chances := f.Chances
+	if f.Comparison != nil {
+		chances = append(slices.Clip(chances), f.Comparison.RivalChances...)
+	}
+	for _, ch := range chances {
 		if ch.IsSetup {
 			fl["has_setup"] = true
 		}

--- a/explainer/render.go
+++ b/explainer/render.go
@@ -253,11 +253,13 @@ func (f *PositionFacts) renderComparison() string {
 		fmt.Fprintf(&ss, "%s is the play %s, and the simulation ranks it first. "+
 			"The comparison below is against the runner-up, %s.\n",
 			c.Play, playSource(c), c.Rival.Play)
+		ss.WriteString(wordNote(c.Play, c.Rival.Play))
 	} else {
 		fmt.Fprintf(&ss, "### Head to head: %s versus %s\n", f.Best.Play, c.Rival.Play)
 		fmt.Fprintf(&ss, "%s is the play %s. Figures below are %s minus %s, so a "+
 			"positive number is the recommended play's advantage.\n",
 			c.Rival.Play, playSource(c), f.Best.Play, c.Rival.Play)
+		ss.WriteString(wordNote(f.Best.Play, c.Rival.Play))
 	}
 
 	d := c.Deltas
@@ -277,8 +279,8 @@ func (f *PositionFacts) renderComparison() string {
 	fmt.Fprintf(&ss, "%-26s %+.2f mean, %+.2f bingo%%\n", "Our next turn", d.OurMeanScore, d.OurBingoPct)
 	// Expected points, not a count of chances: the number is what each play's
 	// big follow-ups add to its next turn over a turn without them.
-	fmt.Fprintf(&ss, "%-26s %.1f pts after %s, %.1f pts after %s\n", "Big follow-up upside",
-		d.BestUpside, f.Best.Play, d.RivalUpside, c.Rival.Play)
+	fmt.Fprintf(&ss, "%-26s %s after %s, %s after %s\n", "Big follow-up upside",
+		upsidePhrase(d.BestUpside), f.Best.Play, upsidePhrase(d.RivalUpside), c.Rival.Play)
 	// Which makes the next-turn line above divisible, and it has to be
 	// divided: the mean difference and the upside difference are one fact
 	// counted twice, and a model given both without the split will argue from
@@ -300,6 +302,53 @@ func (f *PositionFacts) renderComparison() string {
 		fmt.Fprintf(&ss, "No follow-up after %s clears the bar for a big chance.\n", c.Rival.Play)
 	}
 	return ss.String()
+}
+
+// upsidePhrase is what a play's big chances are worth, or that it has none.
+// Zero is not a small upside, it is the absence of a chance that cleared the
+// bar, and the two have to read differently: every figure in this section is
+// one the model is instructed to quote, so a zero formatted like a
+// measurement comes back out at the reader as "your follow-up upside is 0.0"
+// - a field name and a number, which tells a player nothing and sounds like
+// a verdict on their play. Words can only be paraphrased.
+func upsidePhrase(upside float64) string {
+	if upside <= 0 {
+		return "no big follow-up chance"
+	}
+	return fmt.Sprintf("%.1f pts", upside)
+}
+
+// hiddenWord is the word a play's notation hides, and nothing when it hides
+// none: a play with no playthrough is already spelled out, and annotating
+// 2J TOQUE with "makes TOQUE" is noise on every row that needs no help.
+func hiddenWord(play string) string {
+	if !strings.Contains(play, "(") {
+		return ""
+	}
+	return WordFormed(play)
+}
+
+// wordNote spells out whichever plays in the head-to-head have a word hidden
+// by their notation. The reader's own play is usually the one that does, and
+// this is the section the explanation gets written around, so naming BELFRIED
+// here is what stops a player being told about the play FRIED - which is not
+// the play they made, and not a word they can look up.
+func wordNote(plays ...string) string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, p := range plays {
+		w := hiddenWord(p)
+		if w == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, fmt.Sprintf("%s makes the word %s", p, w))
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, ", and ") + ". Name each play by the whole word it makes, " +
+		"never by the letters outside the parentheses alone.\n"
 }
 
 func playSource(c *Comparison) string {
@@ -358,6 +407,11 @@ func (f *PositionFacts) renderCandidates() string {
 			mark = " ❌"
 		}
 		notes := []string{}
+		// The word first: everything else about a play is a fact about a word
+		// the reader has to have read correctly to begin with.
+		if w := hiddenWord(c.Play); w != "" {
+			notes = append(notes, "makes "+w)
+		}
 		if c.IsBingo {
 			notes = append(notes, "bingo")
 		}

--- a/explainer/system.md
+++ b/explainer/system.md
@@ -29,6 +29,13 @@ checkable - a reader who sees the number can go and confirm it, and a reader
 who doesn't has to take your word. They are never padding, and they do not
 count against being terse.
 
+Quote the figures, not the labels they arrived with. The row headings below
+are this program's internal names for things; the reader has never seen them
+and cannot look them up. "Your follow-up upside is 0.0" is a field name and a
+number - say what it means instead: nothing after your play sets up a big
+turn. The test is whether a player could act on the sentence without knowing
+how the analysis is put together.
+
 Draw contrasts with the plays ranked below the winner. If the best play is far
 superior - a bingo, or a big score with nothing comparable available - be very
 concise; there isn't much to explain. People usually ask about positions where

--- a/explainer/tools_test.go
+++ b/explainer/tools_test.go
@@ -128,6 +128,27 @@ func TestGetPlayMetadata(t *testing.T) {
 	is.Equal(md.TilesUsed, 0)
 }
 
+// The word comes off the board, not out of the notation, so the tool answers
+// with LOAF however the model spelled the play - and a model that reads the
+// parentheses as a word boundary gets told otherwise.
+func TestPlayMetadataNamesTheWholeWord(t *testing.T) {
+	is := is.New(t)
+	an := newFollowupAnalyzer(t)
+
+	md, err := an.GetPlayMetadata("13F (L)OAF")
+	is.NoErr(err)
+	is.Equal(md.WordFormed, "LOAF")
+
+	// The dotted form carries no letters to read; the board still has them.
+	md, err = an.GetPlayMetadata("13F .OAF")
+	is.NoErr(err)
+	is.Equal(md.WordFormed, "LOAF")
+
+	md, err = an.GetPlayMetadata("(exch AF)")
+	is.NoErr(err)
+	is.Equal(md.WordFormed, "")
+}
+
 // The agent SDK runs a batch of tool calls one goroutine each, and every tool
 // shares the analyzer's one board. Scoring a vertical play transposes that
 // board in place, so a lookup running beside it reads the mirror image of the


### PR DESCRIPTION
Two ways the fact pack was handing readers something that isn't true.

A play written L5 (BEL)FRIED is BELFRIED, made through a BEL already on the board, and the model was reading the parentheses as a word boundary and telling the player about their play "FRIED" - a word that is nowhere on the board and that they cannot look up. Telling it not to isn't enough on its own, so the word is now in the data. WordFormed reads it out of the notation every play in the fact pack is written in, and the two places the model reads a play before writing about it spell it out: the candidate table annotates the row, and the head to head names the word before the comparison it is about to make. Both go through hiddenWord, so a play with no playthrough - already its own word - collects no note. get_our_play_metadata answers with word_formed too, taken off the board rather than out of the string: the model can ask about a play in dotted form, where the played-through letters aren't in the string to read.

The other is an upside of 0.0. Every figure in that section is one the model is told to quote, and "0.0 pts" formats exactly like a measurement, so it came back out at readers as "your follow-up upside is 0.0" - a field name and a number that reads like a verdict on their play rather than the absence it is. A play with nothing that cleared the bar now has no figure at all, only words, which can only be paraphrased; the system prompt and the big-chance card say what to do with the absence.

While in there: the rival's chances are rendered in the head to head whether or not the best play has any, so they count towards the flags too. A chance belonging to the play the reader actually made was reaching the model with none of the guidance on how to talk about it.


Claude-Session: https://claude.ai/code/session_01AiZbukp4bnM9xkyBRszBoZ