### PR TITLE
Say what the board does, once, or say nothing

### DIFF
--- a/explainer/concepts/board-dynamics.md
+++ b/explainer/concepts/board-dynamics.md
@@ -3,18 +3,14 @@ id: board-dynamics
 priority: 150
 when: has_lane_data
 ---
-**Talking about the board.** You have not been shown a picture of the board.
-What you have is the "Board dynamics" section: the rows and columns the
-simulation's sampled opponent replies actually landed in after each candidate
-play, how often, how much they scored, and which premium squares they covered.
+**Talking about the board.** You have not been shown the board, and you cannot
+work out what is on it. The "What the board does" section is the whole of what
+you know about it: already checked against the simulation, already carrying its
+own conclusion. Put it in your own words and stop there.
 
-That section is the only board information you may use. Within it you can say
-things like "this play leaves the O column quiet" or "after the alternative,
-nearly a fifth of replies come back in row 15 for a mean of 44" - those are
-measured, not guessed.
+Do not name a square, a word, a hook, a premium or a lane that isn't in that
+section, and do not say where any tile sits.
 
-Do not go beyond it. Do not say a play blocks or opens anything that isn't
-named there, do not describe where tiles sit relative to each other, and do not
-work out what words are available. If the lanes look much the same after every
-candidate, the play is not being chosen for what it does to the board, and you
-should say nothing about the board at all.
+When the section is absent, the board is not why this play wins - the opponent
+ends up about as well off either way - and you should say nothing about the
+board at all. Not that it is quiet, not that anything was blocked or opened.

--- a/explainer/concepts/comparison.md
+++ b/explainer/concepts/comparison.md
@@ -31,7 +31,9 @@ Two rules about honesty here:
   separate them, but here is what differs" is the correct answer, and it is
   more useful than a confident story about a gap that isn't there.
 - Their play is not a blunder just because it lost. Say what it was going for,
-  then what it costs. A play that scores more but hands back a live board is a
-  reasonable idea with a specific flaw, and naming the flaw is the lesson.
+  then what it costs - and take what it was going for from the "had going for
+  it" line, which lists every measure it leads on. Do not supply one of your
+  own: a play that scored seven fewer was not going for the bigger score. When
+  that line says it leads on nothing, say that instead.
 
 Address the reader's play directly - "your play", not "the alternative".

--- a/explainer/defense_test.go
+++ b/explainer/defense_test.go
@@ -1,0 +1,186 @@
+package explainer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/domino14/macondo/montecarlo/stats"
+	"github.com/matryer/is"
+)
+
+// laneComparison builds one candidate's board dynamics: the lanes its replies
+// landed in, and how good those replies were overall.
+func laneComparison(play string, best bool, reply ReplyProfile, fp *stats.Footprint,
+	lanes ...*stats.LaneStat) *LaneComparison {
+	return &LaneComparison{
+		Play: play, Best: best, Reply: reply,
+		Stats: &stats.LaneStats{
+			Play: play, Total: 1000, Placements: 900, Footprint: fp, Lanes: lanes,
+		},
+	}
+}
+
+func lane(label string, vertical bool, index int, pct, mean float64) *stats.LaneStat {
+	return &stats.LaneStat{
+		Label: label, Vertical: vertical, Index: index, Count: int(pct * 10),
+		Pct: pct, MeanScore: mean, MaxScore: int(mean) + 20, BestPlay: "x",
+	}
+}
+
+// The complaint the whole gate exists for. Column K goes from a tenth of the
+// opponent's replies to none at all, which reads like the play shut the board
+// down - and the opponent scores exactly as much either way, because their
+// replies simply went somewhere else. Nothing at all is said about the board.
+func TestLaneThatMovesWhileNothingChangesIsNotAFinding(t *testing.T) {
+	is := is.New(t)
+
+	fs := buildBoardFindings([]*LaneComparison{
+		laneComparison("8F TOQUE", true,
+			ReplyProfile{MeanScore: 31.8, BigPct: 12.1, BingoPct: 5.0, Known: true}, nil,
+			lane("row 9", false, 8, 22.0, 30.0)),
+		laneComparison("8B OPAQUED", false,
+			ReplyProfile{MeanScore: 32.4, BigPct: 13.0, BingoPct: 5.2, Known: true}, nil,
+			lane("column K", true, 10, 9.7, 34.0),
+			lane("row 9", false, 8, 20.0, 30.0)),
+	}, "8B OPAQUED")
+	is.Equal(len(fs), 0)
+}
+
+// The other half: a lane that goes quiet and takes the opponent's scoring with
+// it. One lane can carry the whole explanation when the board-wide figures
+// back it, and the finding says so in one sentence.
+func TestLaneBackedByTheWholeBoardIsAFinding(t *testing.T) {
+	is := is.New(t)
+
+	fs := buildBoardFindings([]*LaneComparison{
+		// 2J TOQUE is played in row 2 itself: horizontal, row index 1.
+		laneComparison("2J TOQUE", true,
+			ReplyProfile{MeanScore: 40.4, BigPct: 21.5, BingoPct: 11.2, Known: true},
+			&stats.Footprint{Vertical: false, Index: 1, Start: 9, End: 13},
+			lane("row 2", false, 1, 0.3, 20.0)),
+		laneComparison("L5 (OPA)QUED", false,
+			ReplyProfile{MeanScore: 43.7, BigPct: 33.5, BingoPct: 9.5, Known: true},
+			&stats.Footprint{Vertical: true, Index: 11, Start: 7, End: 10},
+			lane("row 2", false, 1, 40.8, 47.0)),
+	}, "L5 (OPA)QUED")
+	is.Equal(len(fs), 1)
+	fi := fs[0]
+	is.True(fi.Tighter)
+	is.Equal(fi.Lane, "row 2")
+	// The play sitting in the lane is the one that leaves it quiet, so it took
+	// the spot rather than opening it up - the direction the first cut of this
+	// got backwards on every lane it described.
+	is.Equal(fi.Mechanism, MechanismTakesSpot)
+	is.Equal(fi.MechanismPlay, "2J TOQUE")
+
+	text := boardFindingText("2J TOQUE", fi)
+	is.True(strings.Contains(text, "holds the opponent to less"))
+	is.True(strings.Contains(text, "40.4 against 43.7"))
+	is.True(strings.Contains(text, "row 2 that separates them"))
+	is.True(strings.Contains(text, "played in row 2 itself, taking the scoring spot"))
+}
+
+// The same geometry, the other way round: the lane is busy after the play
+// whose tiles run through it, so the replies there are answering those tiles.
+func TestBusyLaneOffThePlaysOwnTilesIsCalledOpening(t *testing.T) {
+	is := is.New(t)
+
+	fs := buildBoardFindings([]*LaneComparison{
+		laneComparison("2J TOQUE", true,
+			ReplyProfile{MeanScore: 45.0, BigPct: 33.0, Known: true},
+			// Horizontal in row 2, its tiles crossing columns J through N.
+			&stats.Footprint{Vertical: false, Index: 1, Start: 9, End: 13},
+			lane("column K", true, 10, 24.0, 41.0)),
+		laneComparison("L5 (OPA)QUED", false,
+			ReplyProfile{MeanScore: 40.0, BigPct: 21.0, Known: true},
+			&stats.Footprint{Vertical: true, Index: 11, Start: 7, End: 10},
+			lane("column K", true, 10, 1.0, 20.0)),
+	}, "L5 (OPA)QUED")
+	is.Equal(len(fs), 1)
+	fi := fs[0]
+	is.True(!fi.Tighter) // the best play is the looser one here
+	is.Equal(fi.Lane, "column K")
+	is.Equal(fi.Mechanism, MechanismOpens)
+	is.Equal(fi.MechanismPlay, "2J TOQUE")
+
+	text := boardFindingText("2J TOQUE", fi)
+	is.True(strings.Contains(text, "leaves the opponent better off"))
+	is.True(strings.Contains(text, "runs its own tiles through column K"))
+}
+
+// A lane can move the wrong way for the finding it would be attached to. The
+// board-wide difference is real, but this lane is not where it lives, and
+// naming it would hand back the story the finding replaces.
+func TestLanePointingTheOtherWayIsLeftOff(t *testing.T) {
+	is := is.New(t)
+
+	fs := buildBoardFindings([]*LaneComparison{
+		laneComparison("2J TOQUE", true,
+			ReplyProfile{MeanScore: 40.4, BigPct: 21.5, Known: true}, nil,
+			lane("row 9", false, 8, 19.4, 36.5)),
+		laneComparison("L5 (OPA)QUED", false,
+			ReplyProfile{MeanScore: 43.7, BigPct: 33.5, Known: true}, nil,
+			lane("row 9", false, 8, 2.7, 30.0)),
+	}, "L5 (OPA)QUED")
+	is.Equal(len(fs), 1)
+	is.True(fs[0].Tighter)
+	is.Equal(fs[0].Lane, "") // row 9 is busier after the tighter play
+
+	text := boardFindingText("2J TOQUE", fs[0])
+	is.True(strings.Contains(text, "holds the opponent to less"))
+	is.True(!strings.Contains(text, "row 9"))
+}
+
+// When the means are level and it is the big replies that moved, the finding
+// has to lead with the big replies. Leading with two means half a point apart
+// invites exactly the overclaim the numbers don't support.
+func TestFindingLedByWhicheverMeasureMoved(t *testing.T) {
+	is := is.New(t)
+
+	fs := buildBoardFindings([]*LaneComparison{
+		laneComparison("12K QU(ID)", true,
+			ReplyProfile{MeanScore: 33.6, BigPct: 24.2, Known: true},
+			&stats.Footprint{Vertical: false, Index: 11, Start: 10, End: 12},
+			lane("row 12", false, 11, 2.2, 20.0)),
+		laneComparison("11J DAC(HA)", false,
+			ReplyProfile{MeanScore: 34.4, BigPct: 33.0, Known: true}, nil,
+			lane("row 12", false, 11, 24.0, 56.6)),
+	}, "11J DAC(HA)")
+	is.Equal(len(fs), 1)
+	is.True(fs[0].Tighter) // on the tail alone: the means are level
+
+	text := boardFindingText("12K QU(ID)", fs[0])
+	is.True(strings.Contains(text, "fewer big turns"))
+	is.True(strings.Contains(text, "mean next turn is much the same"))
+	is.True(!strings.Contains(text, "holds the opponent to less"))
+}
+
+// Defense is measured on the tail as well as the mean: a play can give up the
+// same average reply and still be handing over the occasional huge one.
+func TestBigRepliesAloneEstablishADifference(t *testing.T) {
+	is := is.New(t)
+
+	tight := ReplyProfile{MeanScore: 30.0, BigPct: 8.0, Known: true}
+	loose := ReplyProfile{MeanScore: 31.0, BigPct: 19.0, Known: true}
+	is.Equal(CompareDefense(tight, loose), DefenseTighter)
+	is.Equal(CompareDefense(loose, tight), DefenseLooser)
+
+	// Neither figure moves enough: the opponent is left where they were.
+	same := ReplyProfile{MeanScore: 32.0, BigPct: 12.0, Known: true}
+	is.Equal(CompareDefense(same, ReplyProfile{MeanScore: 34.0, BigPct: 15.0, Known: true}),
+		DefenseFlat)
+	is.Equal(CompareDefense(same, ReplyProfile{}), DefenseUnknown)
+}
+
+func TestFootprintTouches(t *testing.T) {
+	is := is.New(t)
+
+	// 8B OPAQUED: horizontal, row 8, columns B through K.
+	fp := &stats.Footprint{Vertical: false, Index: 7, Start: 1, End: 10}
+	is.True(fp.Touches(false, 7))  // its own row
+	is.True(!fp.Touches(false, 8)) // the row below is not touched
+	is.True(fp.Touches(true, 10))  // column K, its last tile
+	is.True(!fp.Touches(true, 11)) // column L is past the end
+	is.True(!fp.Touches(true, 0))  // column A is before the start
+	is.True(!(*stats.Footprint)(nil).Touches(true, 10))
+}

--- a/explainer/facts.go
+++ b/explainer/facts.go
@@ -2,12 +2,12 @@ package explainer
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
-	"github.com/domino14/macondo/board"
 	"github.com/domino14/macondo/game"
 	"github.com/domino14/macondo/montecarlo"
 	"github.com/domino14/macondo/montecarlo/stats"
@@ -75,6 +75,22 @@ const (
 	laneCandidates = 3
 	laneMinPct     = 4.0
 	lanesShown     = 4
+
+	// How much better the opponent's whole next turn has to be after one play
+	// than after another before the two plays differ in defense at all. Below
+	// these, whatever the lanes did, the opponent is left just as well off and
+	// there is no defensive claim to make.
+	defenseMeanMin   = 3.0
+	defenseBigPctMin = 5.0
+	// Expected points a lane has to account for before it is the place the
+	// difference lives, rather than one more lane that moved a little.
+	laneWorthMin = 3.0
+	// One finding is as much board as an explanation should carry.
+	boardFindingsShown = 1
+
+	// A leave-value gap below this is not something the losing play was going
+	// for; it is two leaves that are the same leave.
+	leaveValueMin = 0.5
 
 	// However many plays the caller simmed, only the top few are worth
 	// contrasting. The shell trims to 5 before it gets here; this bounds the
@@ -268,11 +284,114 @@ func (f *FollowupFact) Worthwhile() bool {
 	return f.IsSetup || f.IsBigChance
 }
 
-// LaneComparison is where one candidate's sampled opponent replies land.
+// LaneComparison is where one candidate's sampled opponent replies land, and
+// how good those replies were board-wide.
 type LaneComparison struct {
 	Play  string
 	Best  bool
 	Stats *stats.LaneStats
+	Reply ReplyProfile
+}
+
+// ReplyProfile is how good the opponent's next turn is after a candidate,
+// taking the whole board at once. The lanes say where their replies landed;
+// this says whether the replies were any good, and it is the only thing a
+// claim about defense can rest on. The opponent answers somewhere every turn,
+// so a lane falling quiet redistributes their plays - on its own it takes
+// nothing away from them.
+type ReplyProfile struct {
+	// MeanScore and BingoPct are the simulation's own figures, so they agree
+	// with the ply table.
+	MeanScore float64 `json:"mean_score"`
+	BingoPct  float64 `json:"bingo_pct"`
+	// BigPct is the share of replies worth stats.BigReplyScore or more - what
+	// an open board actually costs, as against a point or two on the mean. It
+	// is measured over the logged replies, the sample the lanes come from.
+	BigPct float64 `json:"big_pct"`
+	Known  bool    `json:"known"`
+}
+
+// DefenseVerdict is what the board-wide reply profiles say about two plays.
+type DefenseVerdict int
+
+const (
+	// DefenseUnknown is a pair we can't compare, DefenseFlat one where the
+	// opponent does about as well either way - whatever the lanes look like.
+	DefenseUnknown DefenseVerdict = iota
+	DefenseFlat
+	// DefenseTighter means the first play holds the opponent to less;
+	// DefenseLooser means it gives them more.
+	DefenseTighter
+	DefenseLooser
+)
+
+// BoardMechanism is how a lane came to be quiet after one play and busy after
+// another, when the two plays' own squares settle it. Which play sits in the
+// lane does not on its own say which way the traffic went - a play in a lane
+// can take the one scoring spot in it or hand the opponent something to hook
+// onto - so the mechanism is read off the geometry and the measured shares
+// together, never off the geometry alone.
+type BoardMechanism int
+
+const (
+	MechanismNone BoardMechanism = iota
+	// MechanismTakesSpot: the play that leaves the lane quiet is played in
+	// that lane itself. It used the spot up.
+	MechanismTakesSpot
+	// MechanismCrosses: the play that leaves the lane quiet puts tiles across
+	// it from the perpendicular lane.
+	MechanismCrosses
+	// MechanismOpens: the lane is busy only after the play whose own tiles run
+	// through it, so the replies there may be answering those tiles rather
+	// than anything the other play failed to stop.
+	MechanismOpens
+)
+
+// BoardFinding is one thing the board actually does: where the opponent's
+// scoring lived, what the recommended play does to it, and what that was worth
+// across the whole board.
+//
+// The prompt used to carry the lane tables themselves and a set of rules for
+// reading them. That was the wrong shape. Every play makes some lane quieter
+// than some other play, so a table of lane shares is raw material for a
+// defensive story about any play at all, and the rules were an invitation to
+// go looking. What ships now is the conclusion, already gated: no finding
+// means the board is not the reason, and there is nothing left to narrate.
+type BoardFinding struct {
+	Rival string `json:"rival"`
+	// Tighter is true when the best play is the one holding the opponent down.
+	Tighter bool `json:"tighter"`
+	// Best and RivalReply are the two board-wide profiles the finding rests on.
+	Best       ReplyProfile `json:"best"`
+	RivalReply ReplyProfile `json:"rival_reply"`
+	// Lane is where the difference lives, empty when no single lane carries
+	// enough of it to name. The shares and means are that lane's, after each
+	// of the two plays.
+	Lane                string  `json:"lane,omitempty"`
+	BestPct, RivalPct   float64 `json:"-"`
+	BestMean, RivalMean float64 `json:"-"`
+	// Mechanism is how the lane got that way, and MechanismPlay is the play
+	// whose own tiles are in it - the one taking the spot, or the one the
+	// replies are hooking onto.
+	Mechanism     BoardMechanism `json:"mechanism"`
+	MechanismPlay string         `json:"mechanism_play,omitempty"`
+}
+
+// CompareDefense is the gate on every positional claim in the prompt. Two
+// plays differ in defense when the opponent's whole next turn differs: a lower
+// mean, or fewer of the big replies that openness is really about.
+func CompareDefense(best, rival ReplyProfile) DefenseVerdict {
+	if !best.Known || !rival.Known {
+		return DefenseUnknown
+	}
+	meanGap, bigGap := best.MeanScore-rival.MeanScore, best.BigPct-rival.BigPct
+	switch {
+	case meanGap <= -defenseMeanMin || bigGap <= -defenseBigPctMin:
+		return DefenseTighter
+	case meanGap >= defenseMeanMin || bigGap >= defenseBigPctMin:
+		return DefenseLooser
+	}
+	return DefenseFlat
 }
 
 // InferenceFacts is what the opponent's last play gave away, and whether it
@@ -389,6 +508,10 @@ type Comparison struct {
 
 	Deltas Deltas `json:"deltas"`
 
+	// RivalStrengths is every measure the reader's play leads on. Empty means
+	// it leads on none of them, which is a finding of its own.
+	RivalStrengths []string `json:"rival_strengths"`
+
 	// OnlyBest and OnlyRival are the worthwhile follow-up plays each side has
 	// that the other doesn't - the concrete "what you gave up" list.
 	OnlyBest  []*FollowupFact `json:"only_best"`
@@ -452,6 +575,9 @@ type PositionFacts struct {
 	// upside, biggest first.
 	Chances []*FollowupCluster
 	Lanes   []*LaneComparison
+	// BoardFindings is what the board does, already decided. Empty means the
+	// board is not a reason for the play, and nothing about it is sent.
+	BoardFindings []*BoardFinding
 	// TypicalNextScore is what our next turn averages after the best play,
 	// chances and all.
 	TypicalNextScore float64
@@ -542,6 +668,7 @@ func (a *Analyzer) BuildFacts(sim *montecarlo.Simmer, ss *stats.SimStats,
 		}
 	}
 	f.Lanes = laneComparisons(ss, candidates, f.rivalPlay())
+	f.BoardFindings = buildBoardFindings(f.Lanes, f.rivalPlay())
 	f.Inference = buildInference(f, inf)
 
 	f.Flags = computeFlags(f)
@@ -643,7 +770,38 @@ func (a *Analyzer) buildComparison(f *PositionFacts, req *ComparisonRequest, idx
 	c.Deltas.OrdinaryShare = c.Deltas.OurMeanScore - c.Deltas.ChancesShare
 	c.Deltas.SplitKnown = f.TypicalNextScore > 0 && c.TypicalNextScore > 0
 	c.OnlyBest, c.OnlyRival = followupDiff(f.Followups, c.RivalFollowups)
+	c.RivalStrengths = rivalStrengths(f, c)
 	return c, nil
+}
+
+// rivalStrengths is what the reader's play actually had going for it, worked
+// out rather than left to be guessed. Explaining a play they lost with means
+// saying what they were going for, and a model asked for that with only the
+// losing figures in front of it will supply something plausible - "it was
+// going for the bigger score" about a play that scored seven fewer. Every
+// measure the rival genuinely leads on is here, and if it leads on none, that
+// is the honest answer and it is said instead.
+func rivalStrengths(f *PositionFacts, c *Comparison) []string {
+	d, out := c.Deltas, []string{}
+	if d.Score < 0 {
+		out = append(out, fmt.Sprintf("it scores %d more (%d vs %d)",
+			-d.Score, c.Rival.Score, f.Best.Score))
+	}
+	if d.LeaveValue < -leaveValueMin {
+		out = append(out, fmt.Sprintf("it keeps a leave worth %.2f more (%s vs %s)",
+			-d.LeaveValue, dashIfEmpty(c.Rival.Leave), dashIfEmpty(f.Best.Leave)))
+	}
+	if d.OppMeanScore > 0 {
+		out = append(out, fmt.Sprintf("it holds the opponent to %.1f fewer next turn", d.OppMeanScore))
+	}
+	if d.RivalUpside > d.BestUpside {
+		out = append(out, fmt.Sprintf("its follow-up chances are worth %.1f more",
+			d.RivalUpside-d.BestUpside))
+	}
+	if d.OurBingoPct < 0 {
+		out = append(out, fmt.Sprintf("we bingo %.1f%% more often next turn", -d.OurBingoPct))
+	}
+	return out
 }
 
 // buildInference works out whether the read on the opponent's rack is worth
@@ -1301,9 +1459,170 @@ func laneComparisons(ss *stats.SimStats, candidates []montecarlo.CandidateStats,
 			log.Err(err).Str("play", play).Msg("could not compute lane stats")
 			continue
 		}
-		out = append(out, &LaneComparison{Play: play, Best: i == 0, Stats: ls})
+		out = append(out, &LaneComparison{
+			Play:  play,
+			Best:  i == 0,
+			Stats: ls,
+			Reply: replyProfile(findCandidate(candidates, play), ls),
+		})
 	}
 	return out
+}
+
+// replyProfile puts the simulation's figures for the opponent's reply together
+// with the shape of the logged replies. The mean and the bingo rate come from
+// the sim rather than from the log, which is capped: two numbers for the same
+// quantity that disagree by a point would be worse than useless in a prompt
+// that prints the ply table too.
+func replyProfile(c *montecarlo.CandidateStats, ls *stats.LaneStats) ReplyProfile {
+	p := ReplyProfile{}
+	if c == nil || ls == nil || ls.Total == 0 {
+		return p
+	}
+	ps := plyStats(c, 1)
+	if ps == nil {
+		return p
+	}
+	p.MeanScore, p.BingoPct = ps.MeanScore, ps.BingoPct
+	p.BigPct = float64(ls.BigReplies*100) / float64(ls.Total)
+	p.Known = true
+	return p
+}
+
+// boardFlags records only that we have board data at all. Whether the board is
+// worth talking about is decided by whether buildBoardFindings found anything,
+// not by a flag: an empty section is a stronger instruction than any card.
+func (f *PositionFacts) boardFlags() Flags {
+	fl := Flags{}
+	for _, lc := range f.Lanes {
+		if lc.Stats != nil && len(lc.Stats.Lanes) > 0 {
+			fl["has_lane_data"] = true
+		}
+	}
+	return fl
+}
+
+// buildBoardFindings keeps the comparisons where the opponent is genuinely
+// left worse off - or genuinely better off - and throws the rest away.
+//
+// One finding is the cap, and against the reader's own play by preference.
+// The candidates below the top are near-duplicates of each other, so a second
+// finding is usually the same lane described again in the same words, and the
+// mean and big-reply share of every candidate are in the ply table anyway.
+func buildBoardFindings(lanes []*LaneComparison, rivalPlay string) []*BoardFinding {
+	if len(lanes) < 2 || lanes[0].Stats == nil {
+		return nil
+	}
+	best := lanes[0]
+	rivals := slices.Clone(lanes[1:])
+	slices.SortStableFunc(rivals, func(a, b *LaneComparison) int {
+		switch {
+		case a.Play == rivalPlay && b.Play != rivalPlay:
+			return -1
+		case b.Play == rivalPlay && a.Play != rivalPlay:
+			return 1
+		}
+		return 0
+	})
+	out := []*BoardFinding{}
+	for _, rival := range rivals {
+		v := CompareDefense(best.Reply, rival.Reply)
+		if v != DefenseTighter && v != DefenseLooser {
+			continue
+		}
+		fi := &BoardFinding{
+			Rival: rival.Play, Tighter: v == DefenseTighter,
+			Best: best.Reply, RivalReply: rival.Reply,
+		}
+		attachLane(fi, best, rival)
+		out = append(out, fi)
+		if len(out) == boardFindingsShown {
+			break
+		}
+	}
+	return out
+}
+
+// attachLane finds the lane the difference lives in, if one does. It has to
+// point the same way as the board-wide figures: a lane that goes quiet while
+// the opponent ends up better off is their scoring moving, and naming it would
+// hand back exactly the story the finding exists to replace.
+func attachLane(fi *BoardFinding, best, rival *LaneComparison) {
+	var pick *stats.LaneStat
+	var pickBest, pickRival *stats.LaneStat
+	var widest float64
+	for _, l := range candidateLanes(best, rival) {
+		b, r := best.Stats.Lane(l.Vertical, l.Index), rival.Stats.Lane(l.Vertical, l.Index)
+		// Expected points out of the lane, which is the only way a share and a
+		// mean can be compared: a lane taking a fifth of the replies for 20 is
+		// a smaller part of their turn than one taking a twentieth for 90.
+		// A tighter finding wants the lane the best play took away from them,
+		// a looser one the lane it handed over, so the sign has to agree with
+		// the board-wide verdict either way.
+		gain := laneWorth(r) - laneWorth(b)
+		if !fi.Tighter {
+			gain = -gain
+		}
+		if gain >= laneWorthMin && gain > widest {
+			pick, pickBest, pickRival, widest = l, b, r, gain
+		}
+	}
+	if pick == nil {
+		return
+	}
+	fi.Lane = pick.Label
+	fi.BestPct, fi.BestMean = lanePct(pickBest), laneMean(pickBest)
+	fi.RivalPct, fi.RivalMean = lanePct(pickRival), laneMean(pickRival)
+
+	// Which play is quiet in the lane decides what the geometry means. A play
+	// whose tiles are in a lane that then falls silent has taken the scoring
+	// spot in it; a play whose tiles are in a lane that is busy only after it
+	// has given the opponent something to play off.
+	quiet, busy := best, rival
+	if fi.RivalPct < fi.BestPct {
+		quiet, busy = rival, best
+	}
+	qf, bf := footprintOf(quiet), footprintOf(busy)
+	switch {
+	case qf.Touches(pick.Vertical, pick.Index):
+		fi.MechanismPlay = quiet.Play
+		fi.Mechanism = MechanismCrosses
+		if qf.Vertical == pick.Vertical && qf.Index == pick.Index {
+			fi.Mechanism = MechanismTakesSpot
+		}
+	case bf.Touches(pick.Vertical, pick.Index):
+		fi.MechanismPlay, fi.Mechanism = busy.Play, MechanismOpens
+	}
+}
+
+// candidateLanes is every lane either play's replies used enough of to be
+// worth weighing.
+func candidateLanes(comparisons ...*LaneComparison) []*stats.LaneStat {
+	out := []*stats.LaneStat{}
+	seen := map[string]bool{}
+	for _, lc := range comparisons {
+		if lc.Stats == nil {
+			continue
+		}
+		for i, l := range lc.Stats.Lanes {
+			if i >= lanesShown || l.Pct < laneMinPct {
+				break
+			}
+			if !seen[l.Label] {
+				seen[l.Label] = true
+				out = append(out, l)
+			}
+		}
+	}
+	return out
+}
+
+// laneWorth is the expected points the opponent takes out of a lane.
+func laneWorth(l *stats.LaneStat) float64 {
+	if l == nil {
+		return 0
+	}
+	return l.Pct / 100 * l.MeanScore
 }
 
 // computeFlags turns the fact pack into the yes/no answers that select concept
@@ -1399,11 +1718,7 @@ func computeFlags(f *PositionFacts) Flags {
 
 	fl["equity_sacrifice"] = f.BestByEquity != nil && f.BestByEquity.Play != f.Best.Play
 
-	for _, lc := range f.Lanes {
-		if lc.Stats != nil && len(lc.Stats.Lanes) > 0 {
-			fl["has_lane_data"] = true
-		}
-	}
+	maps.Copy(fl, f.boardFlags())
 
 	if f.Comparison != nil && f.Comparison.Rival != nil {
 		fl["has_comparison"] = true
@@ -1417,19 +1732,4 @@ func computeFlags(f *PositionFacts) Flags {
 		fl["inference_changed_play"] = f.Inference.ChangedTopPlay
 	}
 	return fl
-}
-
-// bonusLabel names the premium squares a lane's replies covered, e.g. "TWS,
-// DLS", for prose that talks about what a play opens.
-func bonusLabel(premiums []stats.PremiumUse) string {
-	names := []string{}
-	for _, p := range premiums {
-		if p.Name != "" && p.Bonus != board.NoBonus {
-			names = append(names, p.Name)
-		}
-		if len(names) >= 2 {
-			break
-		}
-	}
-	return strings.Join(names, ", ")
 }

--- a/explainer/render.go
+++ b/explainer/render.go
@@ -72,7 +72,7 @@ func (f *PositionFacts) Render() string {
 		ss.WriteString("\n### What the simulation saw after " + c.Rival.Play + "\n\n")
 		ss.WriteString(c.RivalPlayStats.RenderWith(promptTables))
 	}
-	if s := f.renderBoardDynamics(); s != "" {
+	if s := f.renderBoardFindings(); s != "" {
 		ss.WriteString("\n")
 		ss.WriteString(s)
 	}
@@ -290,6 +290,16 @@ func (f *PositionFacts) renderComparison() string {
 			"ordinary turns.\n", d.OurMeanScore, d.ChancesShare, d.OrdinaryShare)
 	}
 
+	// What their play had going for it, worked out here so it doesn't have to
+	// be guessed at from a table of figures that are all against it.
+	if len(c.RivalStrengths) > 0 {
+		fmt.Fprintf(&ss, "What %s had going for it: %s.\n", c.Rival.Play,
+			strings.Join(c.RivalStrengths, "; "))
+	} else {
+		fmt.Fprintf(&ss, "%s leads on nothing measured here - not the score, not the "+
+			"leave, not what the opponent gets back.\n", c.Rival.Play)
+	}
+
 	writeOpportunities(&ss, "Chances only in the sampled follow-ups after "+f.Best.Play, c.OnlyBest)
 	writeOpportunities(&ss, "Chances only in the sampled follow-ups after "+c.Rival.Play, c.OnlyRival)
 
@@ -447,14 +457,23 @@ func (f *PositionFacts) renderPlies() string {
 			who = "our next turn"
 		}
 		fmt.Fprintf(&ss, "Ply %d (%s)\n", ply, who)
-		fmt.Fprintf(&ss, "%-20s %-9s %-9s %s\n", "Play", "Mean", "Stdev", "Bingo%")
+		// The share of big replies goes in this table rather than in a section
+		// of its own: it is the same measurement as the mean beside it, and it
+		// is the one that says whether a play left the board dangerous. The
+		// stdev barely moves between plays that differ a lot in it.
+		big := ""
+		if ply == 1 {
+			big = fmt.Sprintf("%d+%%", stats.BigReplyScore)
+		}
+		writeRow(&ss, fmt.Sprintf("%-20s %-9s %-9s %-9s %s", "Play", "Mean", "Stdev", "Bingo%", big))
 		for i := range f.Candidates {
 			c := &f.Candidates[i]
 			for _, p := range c.Plies {
 				if p.Ply != ply {
 					continue
 				}
-				fmt.Fprintf(&ss, "%-20s %-9.2f %-9.2f %.2f\n", c.Play, p.MeanScore, p.Stdev, p.BingoPct)
+				writeRow(&ss, fmt.Sprintf("%-20s %-9.2f %-9.2f %-9.2f %s", c.Play,
+					p.MeanScore, p.Stdev, p.BingoPct, bigReplyCell(f.Lanes, c.Play, ply)))
 			}
 		}
 		ss.WriteString("\n")
@@ -529,135 +548,116 @@ func renderChances(heading string, play *montecarlo.CandidateStats,
 	return ss.String()
 }
 
-func (f *PositionFacts) renderBoardDynamics() string {
-	if !f.Flags["has_lane_data"] {
+// renderBoardFindings is the whole of what the prompt says about the board.
+// It used to be a set of lane tables and a page of rules for reading them; the
+// tables turned out to be raw material for a defensive story about whichever
+// play was being explained, since some lane is always quieter after one play
+// than another. What ships now is the conclusion, and only when there is one:
+// no finding means the board is not the reason, and an absent section asks for
+// nothing back.
+func (f *PositionFacts) renderBoardFindings() string {
+	if len(f.BoardFindings) == 0 {
 		return ""
 	}
 	var ss strings.Builder
-	ss.WriteString("### Board dynamics\n")
-	ss.WriteString("Where the opponent's sampled replies actually landed, by lane. " +
-		"These are the only lanes you may make positional claims about; do not " +
-		"work out anything else about the geometry of the board.\n")
-
-	for _, lc := range f.Lanes {
-		label := lc.Play
-		if lc.Best {
-			label += " (the best play)"
-		}
-		fmt.Fprintf(&ss, "\nAfter %s - %d sampled replies", label, lc.Stats.Total)
-		if lc.Stats.Total > 0 {
-			fmt.Fprintf(&ss, ", %.0f%% of them one-tile plays",
-				float64(lc.Stats.SingleTile*100)/float64(lc.Stats.Total))
-		}
-		ss.WriteString("\n")
-		shown := 0
-		for _, l := range lc.Stats.Lanes {
-			if l.Pct < laneMinPct || shown >= lanesShown {
-				break
-			}
-			shown++
-			// Deliberately no single best reply per lane: the top play in a
-			// lane is one sample out of thousands, and quoting it invites
-			// treating a one-off as a threat. How often the lane is used and
-			// what it pays on average is the part that generalizes.
-			extra := ""
-			if b := bonusLabel(l.Premiums); b != "" {
-				extra = "  covers " + b
-			}
-			fmt.Fprintf(&ss, "  %-12s %5.1f%%  mean %5.1f%s\n",
-				l.Label, l.Pct, l.MeanScore, extra)
-		}
-		if shown == 0 {
-			ss.WriteString("  replies were scattered; no lane stands out\n")
-		}
-	}
-
-	if diffs := f.laneDifferences(); len(diffs) > 0 {
-		ss.WriteString("\nWhat the best play changes about the board:\n")
-		for _, d := range diffs {
-			ss.WriteString("  " + d + "\n")
-		}
+	ss.WriteString("### What the board does\n")
+	ss.WriteString("Checked against the simulation and against the board. This is the " +
+		"only positional fact you have: say it in your own words and stop there.\n")
+	for _, fi := range f.BoardFindings {
+		ss.WriteString(boardFindingText(f.Best.Play, fi))
 	}
 	return ss.String()
 }
 
-// Lane percentage / mean-score gaps below these are noise, not a difference in
-// what the play does to the board.
-const (
-	lanePctDiffMin  = 8.0
-	laneMeanDiffMin = 6.0
-)
-
-// laneDifferences compares the best play against the other candidates lane by
-// lane. This is the whole point of computing lanes for more than one play: a
-// lane that is busy after every candidate isn't something this play opened.
-//
-// Each lane gets one line, against whichever other candidate it differs from
-// most - the top candidates are often near-duplicates of each other, and
-// saying the same thing once per near-duplicate is noise.
-func (f *PositionFacts) laneDifferences() []string {
-	if len(f.Lanes) < 2 || f.Lanes[0].Stats == nil {
-		return nil
+func boardFindingText(bestPlay string, fi *BoardFinding) string {
+	var ss strings.Builder
+	// Led by whichever of the two measures actually established the finding. A
+	// play can hold the opponent to the same mean and still take away the big
+	// turns, and quoting the two means first would have the reader checking a
+	// difference of half a point.
+	if abs(fi.Best.MeanScore-fi.RivalReply.MeanScore) >= defenseMeanMin {
+		holds := "holds the opponent to less than"
+		if !fi.Tighter {
+			holds = "leaves the opponent better off than"
+		}
+		fmt.Fprintf(&ss, "%s %s %s: their next turn averages %.1f against %.1f, and is "+
+			"worth %d or more %.1f%% of the time against %.1f%%.\n",
+			bestPlay, holds, fi.Rival, fi.Best.MeanScore, fi.RivalReply.MeanScore,
+			stats.BigReplyScore, fi.Best.BigPct, fi.RivalReply.BigPct)
+	} else {
+		gives := "gives the opponent fewer big turns than"
+		if !fi.Tighter {
+			gives = "gives the opponent more big turns than"
+		}
+		fmt.Fprintf(&ss, "%s %s %s: a reply worth %d or more comes %.1f%% of the time "+
+			"against %.1f%%, though their mean next turn is much the same either way "+
+			"(%.1f against %.1f).\n",
+			bestPlay, gives, fi.Rival, stats.BigReplyScore, fi.Best.BigPct,
+			fi.RivalReply.BigPct, fi.Best.MeanScore, fi.RivalReply.MeanScore)
 	}
-	best := f.Lanes[0]
-	out := []string{}
-	for _, l := range notableLanes(f.Lanes) {
-		b := best.Stats.Lane(l.Vertical, l.Index)
-		bPct, bMean := lanePct(b), laneMean(b)
-
-		// Find the candidate this lane looks least like after our play.
-		var rival *LaneComparison
-		var rivalPct, rivalMean, widest float64
-		for _, other := range f.Lanes[1:] {
-			if other.Stats == nil {
-				continue
-			}
-			o := other.Stats.Lane(l.Vertical, l.Index)
-			if gap := abs(bPct - lanePct(o)); gap > widest {
-				rival, widest = other, gap
-				rivalPct, rivalMean = lanePct(o), laneMean(o)
-			}
-		}
-		if rival == nil {
-			continue
-		}
-
-		switch {
-		case bPct-rivalPct >= lanePctDiffMin:
-			out = append(out, fmt.Sprintf("%s is busier after %s than after %s (%.1f%% vs %.1f%%)",
-				l.Label, best.Play, rival.Play, bPct, rivalPct))
-		case rivalPct-bPct >= lanePctDiffMin:
-			out = append(out, fmt.Sprintf("%s is quieter after %s than after %s (%.1f%% vs %.1f%%)",
-				l.Label, best.Play, rival.Play, bPct, rivalPct))
-		case rivalMean-bMean >= laneMeanDiffMin && rivalPct > 0 && bPct > 0:
-			out = append(out, fmt.Sprintf("replies in %s score less after %s than after %s (mean %.1f vs %.1f)",
-				l.Label, best.Play, rival.Play, bMean, rivalMean))
-		}
+	if fi.Lane == "" {
+		return ss.String()
 	}
-	sort.Strings(out)
-	return out
+	// Busy side first, with its mean. The other side's mean is a handful of
+	// samples and says nothing; what the reader needs is what the lane was
+	// paying whoever had it, and then that it dries up.
+	busy, busyPct, busyMean := fi.Rival, fi.RivalPct, fi.RivalMean
+	quiet, quietPct := bestPlay, fi.BestPct
+	if fi.BestPct > fi.RivalPct {
+		busy, busyPct, busyMean = bestPlay, fi.BestPct, fi.BestMean
+		quiet, quietPct = fi.Rival, fi.RivalPct
+	}
+	fmt.Fprintf(&ss, "  It is %s that separates them: after %s, %.1f%% of their replies "+
+		"land there for a mean of %.1f, against %.1f%% after %s.%s\n",
+		fi.Lane, busy, busyPct, busyMean, quietPct, quiet, mechanismClause(fi))
+	return ss.String()
 }
 
-// notableLanes is the union of the lanes worth showing for any candidate, so a
-// lane that only one of them opens still gets compared.
-func notableLanes(comparisons []*LaneComparison) []*stats.LaneStat {
-	out := []*stats.LaneStat{}
-	seen := map[string]bool{}
-	for _, lc := range comparisons {
-		if lc.Stats == nil {
-			continue
-		}
-		for i, l := range lc.Stats.Lanes {
-			if i >= lanesShown || l.Pct < laneMinPct {
-				break
-			}
-			if !seen[l.Label] {
-				seen[l.Label] = true
-				out = append(out, l)
-			}
+// mechanismClause says how the lane got that way, and says nothing when the
+// two plays' own squares don't settle it. Being in a lane is not by itself
+// blocking it - a play can just as easily give the opponent something to hook
+// onto - so the clause is only ever the geometry and the measured shares read
+// together.
+func mechanismClause(fi *BoardFinding) string {
+	switch fi.Mechanism {
+	case MechanismTakesSpot:
+		return fmt.Sprintf(" %s is played in %s itself, taking the scoring spot in it.",
+			fi.MechanismPlay, fi.Lane)
+	case MechanismCrosses:
+		return fmt.Sprintf(" %s puts its own tiles across %s.", fi.MechanismPlay, fi.Lane)
+	case MechanismOpens:
+		return fmt.Sprintf(" %s runs its own tiles through %s, which is what the replies "+
+			"there are answering.", fi.MechanismPlay, fi.Lane)
+	}
+	return ""
+}
+
+// writeRow writes a padded table row without the padding that ran off the end
+// of it: the last column is empty on the ply we have no big-reply figures for.
+func writeRow(ss *strings.Builder, row string) {
+	ss.WriteString(strings.TrimRight(row, " ") + "\n")
+}
+
+// bigReplyCell is how often the opponent's reply was a big one, for the plays
+// we have logged replies for. It is blank for the rest rather than zero: a
+// play whose replies were never sampled did not hold anyone to anything.
+func bigReplyCell(lanes []*LaneComparison, play string, ply int) string {
+	if ply != 1 {
+		return ""
+	}
+	for _, lc := range lanes {
+		if lc.Play == play && lc.Reply.Known {
+			return fmt.Sprintf("%.2f", lc.Reply.BigPct)
 		}
 	}
-	return out
+	return "-"
+}
+
+func footprintOf(lc *LaneComparison) *stats.Footprint {
+	if lc == nil || lc.Stats == nil {
+		return nil
+	}
+	return lc.Stats.Footprint
 }
 
 func abs(f float64) float64 {

--- a/montecarlo/stats/lanes.go
+++ b/montecarlo/stats/lanes.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/domino14/macondo/board"
 	"github.com/domino14/macondo/move"
 	"github.com/domino14/word-golib/tilemapping"
 )
@@ -19,12 +18,40 @@ import (
 // the heat map throws away, so the AI explainer can make positional claims
 // that come from sampled data rather than from reading a picture of a board.
 
-// PremiumUse counts how many sampled plays in a lane covered a premium square
-// of a given kind.
-type PremiumUse struct {
-	Bonus board.BonusSquare `json:"-"`
-	Name  string            `json:"name"`
-	Count int               `json:"count"`
+// BigReplyScore is what makes a reply a big one. What an open board costs you
+// is the occasional huge turn rather than a point or two on the average one,
+// so this is the figure a claim about openness rests on - and unlike a lane
+// share, it is board-wide: the opponent replies somewhere every turn, so
+// closing one lane moves their plays around without necessarily making any of
+// them worse.
+const BigReplyScore = 50
+
+// Footprint is where a play puts its new tiles: the lane it sits in, and how
+// far it reaches across the perpendicular ones. A lane can fall silent after a
+// play for a reason that has nothing to do with defense - the tiles that made
+// it a lane at all are the other candidate's - and this is what tells that
+// case apart from a play that really did shut the lane down.
+type Footprint struct {
+	Vertical bool `json:"vertical"`
+	// Index is the play's own lane: its row if horizontal, its column if
+	// vertical.
+	Index int `json:"index"`
+	// Start and End bound the perpendicular lanes it drops a new tile in.
+	// Playthrough tiles are left out: they were on the board already, so the
+	// lanes crossing them were reachable before this play too.
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// Touches reports whether the play puts a new tile in the given lane.
+func (fp *Footprint) Touches(vertical bool, index int) bool {
+	if fp == nil {
+		return false
+	}
+	if vertical == fp.Vertical {
+		return index == fp.Index
+	}
+	return index >= fp.Start && index <= fp.End
 }
 
 // LaneStat summarizes the sampled plays that landed in one row or column.
@@ -33,17 +60,19 @@ type LaneStat struct {
 	Label    string `json:"label"`
 	Vertical bool   `json:"vertical"`
 	// Index is the 0-based row (horizontal) or column (vertical).
-	Index      int          `json:"index"`
-	Count      int          `json:"count"`
-	Pct        float64      `json:"pct"`
-	MeanScore  float64      `json:"mean_score"`
-	MaxScore   int          `json:"max_score"`
-	BestPlay   string       `json:"best_play"`
-	BingoCount int          `json:"bingo_count"`
-	Premiums   []PremiumUse `json:"premiums,omitempty"`
+	Index int `json:"index"`
+	// The premium squares a lane's replies covered used to be counted here
+	// too, and named in the prompt as "covers TLS, DWS". The model read the
+	// abbreviations back out as prose about "the dangerous triple lane", which
+	// is a claim about the board nobody measured, so nothing counts them now.
+	Count      int     `json:"count"`
+	Pct        float64 `json:"pct"`
+	MeanScore  float64 `json:"mean_score"`
+	MaxScore   int     `json:"max_score"`
+	BestPlay   string  `json:"best_play"`
+	BingoCount int     `json:"bingo_count"`
 
 	totalScore int
-	premiums   map[board.BonusSquare]int
 }
 
 // LaneStats is the lane breakdown of every sampled continuation of one root
@@ -64,6 +93,14 @@ type LaneStats struct {
 	SingleTile int `json:"single_tile"`
 	// Scoreless counts passes and exchanges.
 	Scoreless int `json:"scoreless"`
+	// BigReplies counts sampled continuations worth BigReplyScore or more,
+	// wherever they landed - one-tile plays included. This is the board-wide
+	// measure of what the root play left open, as against the per-lane shares
+	// below, which only say where the opponent went.
+	BigReplies int     `json:"big_replies"`
+	BigPct     float64 `json:"big_pct"`
+	// Footprint is where the root play itself sits.
+	Footprint *Footprint `json:"footprint,omitempty"`
 	// Lanes is sorted by Count, most frequent first.
 	Lanes []*LaneStat `json:"lanes"`
 }
@@ -96,6 +133,13 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 	}
 	normalizedPlay := Normalize(play)
 	ls := &LaneStats{Play: play, Ply: ply}
+	if p, err := ss.parsePlacement(normalizedPlay); err != nil {
+		return nil, err
+	} else if p != nil {
+		ls.Footprint = &Footprint{
+			Vertical: p.vertical, Index: p.index, Start: p.start, End: p.end,
+		}
+	}
 	byLane := map[[2]int]*LaneStat{}
 
 	for i := range iters {
@@ -109,6 +153,9 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 			logPlay := iters[i].Plays[j].Plies[ply]
 			analyzedPlay := Normalize(logPlay.Play)
 			ls.Total++
+			if logPlay.Pts >= BigReplyScore {
+				ls.BigReplies++
+			}
 
 			if strings.HasPrefix(analyzedPlay, "exchange ") ||
 				analyzedPlay == "pass" || analyzedPlay == "UNHANDLED" {
@@ -116,45 +163,20 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 				continue
 			}
 
-			playFields := strings.Fields(analyzedPlay)
-			if len(playFields) != 2 {
-				log.Debug().Str("play", analyzedPlay).Msg("skipping unparseable ply play")
-				continue
-			}
-			row, col, vertical := move.FromBoardGameCoords(strings.ToUpper(playFields[0]), false)
-			mw, err := tilemapping.ToMachineWord(playFields[1], ss.game.Alphabet())
+			p, err := ss.parsePlacement(analyzedPlay)
 			if err != nil {
 				return nil, err
 			}
-			ri, ci := 1, 0
-			if !vertical {
-				ri, ci = 0, 1
+			if p == nil {
+				continue
 			}
-
-			// Collect the squares this play actually covers. Playthrough
-			// tiles were already on the board, so they cover nothing.
-			placed := 0
-			bonuses := map[board.BonusSquare]bool{}
-			for idx := range mw {
-				if mw[idx] == 0 {
-					continue
-				}
-				placed++
-				b := ss.board.GetBonus(row+(ri*idx), col+(ci*idx))
-				if b != board.NoBonus {
-					bonuses[b] = true
-				}
-			}
-			if placed < 2 {
+			if p.placed < 2 {
 				ls.SingleTile++
 				continue
 			}
 			ls.Placements++
 
-			index := row
-			if vertical {
-				index = col
-			}
+			vertical, index := p.vertical, p.index
 			key := [2]int{index, boolToInt(vertical)}
 			l, ok := byLane[key]
 			if !ok {
@@ -162,7 +184,6 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 					Label:    LaneLabel(vertical, index),
 					Vertical: vertical,
 					Index:    index,
-					premiums: map[board.BonusSquare]int{},
 				}
 				byLane[key] = l
 			}
@@ -175,10 +196,11 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 			if logPlay.Bingo {
 				l.BingoCount++
 			}
-			for b := range bonuses {
-				l.premiums[b]++
-			}
 		}
+	}
+
+	if ls.Total > 0 {
+		ls.BigPct = float64(ls.BigReplies*100) / float64(ls.Total)
 	}
 
 	for _, l := range byLane {
@@ -188,15 +210,6 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 		if ls.Total > 0 {
 			l.Pct = float64(l.Count*100) / float64(ls.Total)
 		}
-		for b, ct := range l.premiums {
-			l.Premiums = append(l.Premiums, PremiumUse{Bonus: b, Name: b.Name(), Count: ct})
-		}
-		sort.Slice(l.Premiums, func(i, j int) bool {
-			if l.Premiums[i].Count != l.Premiums[j].Count {
-				return l.Premiums[i].Count > l.Premiums[j].Count
-			}
-			return l.Premiums[i].Name < l.Premiums[j].Name
-		})
 		ls.Lanes = append(ls.Lanes, l)
 	}
 	sort.Slice(ls.Lanes, func(i, j int) bool {
@@ -210,6 +223,65 @@ func (ss *SimStats) CalculateLaneStats(play string, ply int) (*LaneStats, error)
 	})
 
 	return ls, nil
+}
+
+// placement is where one play put its new tiles, and what those squares are
+// worth. The root play and every sampled reply are read the same way, so a
+// footprint and a lane are measured on the same terms.
+type placement struct {
+	vertical bool
+	// index is the play's own lane, start and end the perpendicular lanes it
+	// places tiles in.
+	index      int
+	start, end int
+	placed     int
+}
+
+// parsePlacement reads a normalized play - "8D W.RD", with dots for the tiles
+// already on the board. It returns nil, nil for anything it cannot read as a
+// placement, which is not an error: an unparseable line in the log costs us
+// one sample, not the whole analysis.
+func (ss *SimStats) parsePlacement(analyzedPlay string) (*placement, error) {
+	playFields := strings.Fields(analyzedPlay)
+	if len(playFields) != 2 {
+		log.Debug().Str("play", analyzedPlay).Msg("skipping unparseable play")
+		return nil, nil
+	}
+	row, col, vertical := move.FromBoardGameCoords(strings.ToUpper(playFields[0]), false)
+	mw, err := tilemapping.ToMachineWord(playFields[1], ss.game.Alphabet())
+	if err != nil {
+		return nil, err
+	}
+	ri, ci := 1, 0
+	if !vertical {
+		ri, ci = 0, 1
+	}
+
+	p := &placement{vertical: vertical, index: row}
+	if vertical {
+		p.index = col
+	}
+	// Only the squares this play actually covers. Playthrough tiles were on
+	// the board already, so they open no lane that wasn't open before.
+	for idx := range mw {
+		if mw[idx] == 0 {
+			continue
+		}
+		r, c := row+(ri*idx), col+(ci*idx)
+		cross := c
+		if vertical {
+			cross = r
+		}
+		if p.placed == 0 {
+			p.start, p.end = cross, cross
+		}
+		p.start, p.end = min(p.start, cross), max(p.end, cross)
+		p.placed++
+	}
+	if p.placed == 0 {
+		return nil, nil
+	}
+	return p, nil
 }
 
 func boolToInt(b bool) int {


### PR DESCRIPTION
The board section handed the model lane tables and rules for reading them. Every play makes some lane quieter than some other play - the opponent answers somewhere every turn - so the tables were raw material for a defensive story about whichever play was being explained, and the rules were an invitation to go looking for one. The stories came out accordingly: a column that fell to 0.0% because the play never reached that part of the board, read back as the play shutting the board down.

What ships now is the conclusion. A finding exists only when the opponent's whole next turn is worse - a lower mean, or fewer of the big replies that openness actually costs - and then names the one lane the difference lives in. No finding means the board is not the reason, and an empty section asks for nothing back, which two concept cards telling it not to talk about the board could not manage.

The mechanism under a lane is read off the geometry and the measured shares together. Which play sits in a lane does not say which way the traffic went: a play in a lane can take the one scoring spot in it or give the opponent something to hook onto, and the difference is which side ended up quiet.

Also gone: the premium squares each lane covered, printed as "covers TLS, DWS" and read back out as prose about the dangerous triple lane, which is a claim about the board nobody measured.

The head-to-head now works out what the reader's play led on. Asked to say what a losing play was going for, with only the figures against it in front of it, the model supplied something plausible - "it was going for the bigger score", about a play that scored seven fewer.

Net, on the same position: 352 prompt lines to 322.


Claude-Session: https://claude.ai/code/session_01Egc5B6cgNgV2P6fjmatcML