### PR TITLE
Fix index out of range in WMP anchor table

### DIFF
--- a/wmp/movegen.go
+++ b/wmp/movegen.go
@@ -22,7 +22,9 @@ const (
 	MaxPossiblePlaythroughBlocks = (15 / 2) + 1
 	// MaxWMPMoveGenAnchors is the size of the per-anchor scratch
 	// table indexed by (playthrough_blocks, tiles_to_play).
-	MaxWMPMoveGenAnchors = (RackSize + 1) * MaxPossiblePlaythroughBlocks
+	// playthrough_blocks ranges 0..MaxPossiblePlaythroughBlocks
+	// inclusive, so the table needs one extra row.
+	MaxWMPMoveGenAnchors = (RackSize + 1) * (MaxPossiblePlaythroughBlocks + 1)
 )
 
 // EquityMinValue is the sentinel returned for "no anchor seen yet"


### PR DESCRIPTION
## Summary
- The WMP anchor scratch table was sized for `playthrough_blocks` 0..7, but a word can cross 8 disjoint playthrough runs on a 15-wide board (single tiles on every even column, all 7 rack tiles played into the gaps), producing index 71 in a 64-slot array and panicking in `MaybeUpdateAnchor` during sims.
- Size the table with `MaxPossiblePlaythroughBlocks + 1` rows, since block count zero also occupies a row.

Reproduced with the crashing volunteer-mode game's position (FRA24/french):

```
load cgp 6OXO2FLIP/5QUI1G1R2R/7SKIEES1I/9C1L2V/5TAILLEES1E/4VU3O4N/3P3TANNEZ1T/3O2WONS1N3/2JE1BUN3F3/1HALDES4U3/2RA4MATIR2/2D8R3/2S3EMECHaI2/15/15 ADEEMRU/AABEOTU 304/339 0 lex FRA24; ld french;
gen 40
sim -plies 5 -stop 99
```

Panics before the fix (`index out of range [71] with length 64`, wmp/movegen.go:419); sim runs to completion after.

MAGPIE had the same bug; it was reported upstream (jvc56/MAGPIE#676) and fixed identically in jvc56/MAGPIE#677 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHJc868abUgvVQ5pCQpHS8